### PR TITLE
My poems page navigation

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,10 +2,12 @@ import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 
 import {HomeComponent} from './home/home.component';
+import {MyPoemsComponent} from './my-poems/my-poems.component';
 
 export const routes: Routes = [
-  {path: 'home/', component: HomeComponent},
-  {path: '**', redirectTo: 'home/'},
+  {path: 'my_poems', component: MyPoemsComponent},
+  {path: 'home', component: HomeComponent},
+  {path: '**', redirectTo: 'home'},
 ];
 
 @NgModule({

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,6 +2,7 @@ import {Location} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {MatDividerModule} from '@angular/material/divider';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 
@@ -21,8 +22,9 @@ describe('AppComponent', () => {
     TestBed
         .configureTestingModule({
           imports: [
-            MatDividerModule,
             MatButtonModule,
+            MatDividerModule,
+            MatProgressSpinnerModule,
             RouterTestingModule.withRoutes(routes),
           ],
           declarations: [

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -53,6 +53,6 @@ describe('AppComponent', () => {
 
   it('should default to the home page', () => {
     const location = TestBed.inject(Location);
-    expect(location.path()).toBe('/home/');
+    expect(location.path()).toBe('/home');
   });
 });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import {ExampleComponent} from './example/example.component';
 import {HomeComponent} from './home/home.component';
 import {LoginButtonComponent} from './login-button/login-button.component';
 import {MaterialModule} from './material/material.module';
+import {MyPoemsComponent} from './my-poems/my-poems.component';
 import {NavigationComponent} from './navigation/navigation.component';
 
 @NgModule({
@@ -20,6 +21,7 @@ import {NavigationComponent} from './navigation/navigation.component';
     LoginButtonComponent,
     HomeComponent,
     NavigationComponent,
+    MyPoemsComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/login-button/login-button.component.css
+++ b/src/app/login-button/login-button.component.css
@@ -15,3 +15,7 @@
 .user-email-label {
     margin-left: 10px;
 }
+
+.login-spinner {
+    margin-left: 10px;
+}

--- a/src/app/login-button/login-button.component.html
+++ b/src/app/login-button/login-button.component.html
@@ -1,5 +1,8 @@
-<button mat-raised-button class="login-button" (click)="logInOrOut()">
-    <span class="icon"></span>
-    {{getUserEmail()?"Sign Out":"Sign In with Google"}}
-</button>
-<label *ngIf="getUserEmail() as email" class="user-email-label">{{email}}</label>
+<div class="flex-horizontal" style="align-items: center;">
+    <button mat-raised-button class="login-button" (click)="logInOrOut()">
+        <span class="icon"></span>
+        {{getUserEmail()?"Sign Out":"Sign In with Google"}}
+    </button>
+    <mat-spinner *ngIf="isLoggingIn" diameter="25" class="login-spinner"></mat-spinner>
+    <label *ngIf="getUserEmail() as email" class="user-email-label">{{email}}</label>
+</div>

--- a/src/app/login-button/login-button.component.spec.ts
+++ b/src/app/login-button/login-button.component.spec.ts
@@ -3,6 +3,8 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {MatButtonHarness} from '@angular/material/button/testing';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {MatProgressSpinnerHarness} from '@angular/material/progress-spinner/testing';
 
 import {AuthService} from '../auth.service';
 import {BackendService} from '../backend.service';
@@ -27,6 +29,7 @@ describe('LoginButtonComponent', () => {
         .configureTestingModule({
           imports: [
             MatButtonModule,
+            MatProgressSpinnerModule,
           ],
           declarations: [LoginButtonComponent],
           providers: [
@@ -111,5 +114,12 @@ describe('LoginButtonComponent', () => {
 
     expect(backendServiceStub.createUser)
         .toHaveBeenCalledOnceWith(expectedEmail);
+  });
+
+  it('should show a spinner while login is in progress', async () => {
+    component.isLoggingIn = true;
+    const spinner = await loader.getHarness(
+        MatProgressSpinnerHarness.with({selector: '.login-spinner'}));
+    expect(spinner).toBeDefined();
   });
 });

--- a/src/app/login-button/login-button.component.ts
+++ b/src/app/login-button/login-button.component.ts
@@ -9,25 +9,32 @@ import {BackendService} from '../backend.service';
   styleUrls: ['./login-button.component.css']
 })
 export class LoginButtonComponent {
+  isLoggingIn: boolean;
+
   constructor(
       private authService: AuthService,
       private backendService: BackendService,
   ) {}
 
   async logInOrOut(): Promise<void> {
-    await this.authService.logInOrOut();
+    try {
+      this.isLoggingIn = true;
+      await this.authService.logInOrOut();
 
-    const userEmail = this.getUserEmail();
-    if (userEmail) {
-      const response =
-          await firstValueFrom(this.backendService.createUser(userEmail));
+      const userEmail = this.getUserEmail();
+      if (userEmail) {
+        const response =
+            await firstValueFrom(this.backendService.createUser(userEmail));
 
-      if (!response) {
-        console.error(
-            'Failed to get a response from the backend for creating a user');
-      } else {
-        console.log(response);
+        if (!response) {
+          console.error(
+              'Failed to get a response from the backend for creating a user');
+        } else {
+          console.log(response);
+        }
       }
+    } finally {
+      this.isLoggingIn = false;
     }
   }
 

--- a/src/app/my-poems/my-poems.component.html
+++ b/src/app/my-poems/my-poems.component.html
@@ -1,0 +1,1 @@
+<p>my-poems works!</p>

--- a/src/app/my-poems/my-poems.component.spec.ts
+++ b/src/app/my-poems/my-poems.component.spec.ts
@@ -1,0 +1,23 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {MyPoemsComponent} from './my-poems.component';
+
+describe('MyPoemsComponent', () => {
+  let component: MyPoemsComponent;
+  let fixture: ComponentFixture<MyPoemsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({declarations: [MyPoemsComponent]})
+        .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MyPoemsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/my-poems/my-poems.component.ts
+++ b/src/app/my-poems/my-poems.component.ts
@@ -1,0 +1,9 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-my-poems',
+  templateUrl: './my-poems.component.html',
+  styleUrls: ['./my-poems.component.css']
+})
+export class MyPoemsComponent {
+}

--- a/src/app/navigation/navigation.component.css
+++ b/src/app/navigation/navigation.component.css
@@ -1,3 +1,7 @@
 .nav-buttons a {
     margin-right: 10px
 }
+
+.nav-buttons a[disabled="true"] {
+    pointer-events: none;
+}

--- a/src/app/navigation/navigation.component.html
+++ b/src/app/navigation/navigation.component.html
@@ -1,4 +1,5 @@
 <nav class="nav-buttons">
-    <a mat-flat-button class="home-nav" [routerLink]="['home/']" [color]="router.url=='/home/'?'primary':''">Home</a>
-    <a mat-flat-button class="my-poems-nav" [disabled]="!userIsLoggedIn()">My Poems</a>
+    <a mat-flat-button class="home-nav" routerLink="/home" [color]="getButtonColor('/home')">Home</a>
+    <a mat-flat-button class="my-poems-nav" routerLink="/my_poems" [color]="getButtonColor('/my_poems')"
+        [disabled]="!userIsLoggedIn()">My Poems</a>
 </nav>

--- a/src/app/navigation/navigation.component.spec.ts
+++ b/src/app/navigation/navigation.component.spec.ts
@@ -1,8 +1,10 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Location} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {MatButtonHarness} from '@angular/material/button/testing';
+import {Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 
 import {routes} from '../app-routing.module';
@@ -16,6 +18,8 @@ describe('NavigationComponent', () => {
   let component: NavigationComponent;
   let fixture: ComponentFixture<NavigationComponent>;
   let loader: HarnessLoader;
+  let location: Location;
+  let router: Router;
 
   beforeEach(async () => {
     authServiceStub = new AuthServiceStub();
@@ -36,6 +40,8 @@ describe('NavigationComponent', () => {
     fixture = TestBed.createComponent(NavigationComponent);
     component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
+    location = TestBed.inject(Location);
+    router = TestBed.inject(Router);
     fixture.detectChanges();
   });
 
@@ -48,8 +54,8 @@ describe('NavigationComponent', () => {
        const myPoemsNavButton = await loader.getHarness(
            MatButtonHarness.with({selector: '.my-poems-nav'}));
 
-       // Initially should not be disabled since the auth stub starts with a
-       // user
+       // Initially should not be disabled since the
+       // auth stub starts with a user
        expect(await myPoemsNavButton.isDisabled()).toBeFalse();
 
        authServiceStub.clearUser();
@@ -57,4 +63,26 @@ describe('NavigationComponent', () => {
 
        expect(await myPoemsNavButton.isDisabled()).toBeTrue();
      });
+
+  it('should navigate to the My Poems page', async () => {
+    const myPoemsNavButton = await loader.getHarness(
+        MatButtonHarness.with({selector: '.my-poems-nav'}));
+    await myPoemsNavButton.click();
+
+    fixture.detectChanges();
+    expect(location.path()).toBe('/my_poems');
+  });
+
+  it('should navigate to the Home page', async () => {
+    // Default is home page, first navigate off
+    await router.navigate(['/my_poems']);
+    expect(location.path()).toBe('/my_poems');
+
+    const homeNavButton =
+        await loader.getHarness(MatButtonHarness.with({selector: '.home-nav'}));
+    await homeNavButton.click();
+
+    fixture.detectChanges();
+    expect(location.path()).toBe('/home');
+  });
 });

--- a/src/app/navigation/navigation.component.spec.ts
+++ b/src/app/navigation/navigation.component.spec.ts
@@ -65,24 +65,32 @@ describe('NavigationComponent', () => {
      });
 
   it('should navigate to the My Poems page', async () => {
+    const expectedRoute = '/my_poems';
+
     const myPoemsNavButton = await loader.getHarness(
         MatButtonHarness.with({selector: '.my-poems-nav'}));
+    expect(component.getButtonColor(expectedRoute)).toBe('basic');
     await myPoemsNavButton.click();
 
     fixture.detectChanges();
-    expect(location.path()).toBe('/my_poems');
+    expect(location.path()).toBe(expectedRoute);
+    expect(component.getButtonColor(expectedRoute)).toBe('primary');
   });
 
   it('should navigate to the Home page', async () => {
+    const expectedRoute = '/home';
+
     // Default is home page, first navigate off
     await router.navigate(['/my_poems']);
     expect(location.path()).toBe('/my_poems');
 
     const homeNavButton =
         await loader.getHarness(MatButtonHarness.with({selector: '.home-nav'}));
+    expect(component.getButtonColor(expectedRoute)).toBe('basic');
     await homeNavButton.click();
 
     fixture.detectChanges();
-    expect(location.path()).toBe('/home');
+    expect(location.path()).toBe(expectedRoute);
+    expect(component.getButtonColor(expectedRoute)).toBe('primary');
   });
 });

--- a/src/app/navigation/navigation.component.ts
+++ b/src/app/navigation/navigation.component.ts
@@ -10,10 +10,14 @@ import {AuthService} from '../auth.service';
 export class NavigationComponent {
   constructor(
       private authService: AuthService,
-      public router: Router,
+      private router: Router,
   ) {}
 
   userIsLoggedIn(): boolean {
     return this.authService.getUserEmail() != undefined;
+  }
+
+  getButtonColor(route: string): string {
+    return this.router.url.startsWith(route) ? 'primary' : 'basic';
   }
 }


### PR DESCRIPTION
Add navigation to an empty My Poems page.

Previously, the My Poems navigation button at the top of the app did not do anything.
Now, the button will lead to an empty My Poems page if the user is signed in.
Additionally, a loading spinner was added for when the user in the middle of signing in.

Disabled My Poems button when the user is not logged in:
![image](https://user-images.githubusercontent.com/15317173/117368962-e1624b00-ae89-11eb-8ba3-f090e4d5ba9b.png)

Loading spinner while signing in:
![image](https://user-images.githubusercontent.com/15317173/117369087-08b91800-ae8a-11eb-88ed-8ccf5eb73db2.png)

My Poems page:
![image](https://user-images.githubusercontent.com/15317173/117369125-18386100-ae8a-11eb-9f66-0adaeed500ee.png)

Added tests for:
-check that the navigation buttons route to the my poems page
-check that the navigation buttons route to the home page
-check that the sign in button has a spinner when sign in is in progress
