### PR TITLE
My poems skeleton

### DIFF
--- a/sql/tables/poem.sql
+++ b/sql/tables/poem.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `poem` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `creation_timestamp` datetime NOT NULL,
+  `modified_timestamp` datetime DEFAULT NULL,
+  `privacy_level` enum('public','private') NOT NULL DEFAULT 'public',
+  `archived` bit(1) NOT NULL DEFAULT b'0',
+  `form` enum('haiku','sonnet','tonka') DEFAULT NULL,
+  `generated` bit(1) NOT NULL DEFAULT b'0',
+  `text` varchar(8000) NOT NULL,
+  `num_likes` int NOT NULL DEFAULT '0',
+  `num_dislikes` int NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id_UNIQUE` (`id`),
+  KEY `user_fk_idx` (`user_id`),
+  CONSTRAINT `user_fk` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/app/my-poems/my-poems.component.css
+++ b/src/app/my-poems/my-poems.component.css
@@ -1,0 +1,7 @@
+.my-poems-content {
+    height: 100%;
+}
+
+.my-poems-content .my-poems-tile-content {
+    height: 100%;
+}

--- a/src/app/my-poems/my-poems.component.html
+++ b/src/app/my-poems/my-poems.component.html
@@ -1,1 +1,19 @@
-<p>my-poems works!</p>
+<div class="my-poems-content">
+    <mat-grid-list cols="3">
+        <mat-grid-tile>
+            <div class="my-poems-tile-content">
+                <h1>My Poems</h1>
+            </div>
+        </mat-grid-tile>
+        <mat-grid-tile>
+            <div class="my-poems-tile-content">
+                <h1>Liked Poems</h1>
+            </div>
+        </mat-grid-tile>
+        <mat-grid-tile>
+            <div class="my-poems-tile-content">
+                <h1>Generated Poems</h1>
+            </div>
+        </mat-grid-tile>
+    </mat-grid-list>
+</div>

--- a/src/app/my-poems/my-poems.component.spec.ts
+++ b/src/app/my-poems/my-poems.component.spec.ts
@@ -1,19 +1,30 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatGridListModule} from '@angular/material/grid-list';
 
 import {MyPoemsComponent} from './my-poems.component';
 
 describe('MyPoemsComponent', () => {
   let component: MyPoemsComponent;
   let fixture: ComponentFixture<MyPoemsComponent>;
+  let loader: HarnessLoader;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({declarations: [MyPoemsComponent]})
+    await TestBed
+        .configureTestingModule({
+          imports: [
+            MatGridListModule,
+          ],
+          declarations: [MyPoemsComponent],
+        })
         .compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyPoemsComponent);
     component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
   });
 


### PR DESCRIPTION
Create a skeleton My Poems page what will contain information about a user's poems.

Previously, the My Poems page only shows an empty page.
Now, the my Poems page shows a skeleton with areas that will later be filled in by a user's written, liked, and generated poems.
Additionally, a SQL table creation statement was added for the creation of the Poem table.

My Poems skeleton:
![image](https://user-images.githubusercontent.com/15317173/117718085-45925100-b1a1-11eb-8b15-94f54174e469.png)
