### PR TITLE
My poems edit dialog

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,6 +2,7 @@ import {Location} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {MatDividerModule} from '@angular/material/divider';
+import {MatGridListModule} from '@angular/material/grid-list';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
@@ -24,6 +25,7 @@ describe('AppComponent', () => {
           imports: [
             MatButtonModule,
             MatDividerModule,
+            MatGridListModule,
             MatProgressSpinnerModule,
             RouterTestingModule.withRoutes(routes),
           ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,10 +11,10 @@ import {ExampleComponent} from './example/example.component';
 import {HomeComponent} from './home/home.component';
 import {LoginButtonComponent} from './login-button/login-button.component';
 import {MaterialModule} from './material/material.module';
+import {MyPoemsEditDialog} from './my-poems-edit-dialog/my-poems-edit-dialog.component';
+import {MyPoemsListComponent} from './my-poems-list/my-poems-list.component';
 import {MyPoemsComponent} from './my-poems/my-poems.component';
 import {NavigationComponent} from './navigation/navigation.component';
-import { MyPoemsEditDialogComponent } from './my-poems-edit-dialog/my-poems-edit-dialog.component';
-import { MyPoemsListComponent } from './my-poems-list/my-poems-list.component';
 
 @NgModule({
   declarations: [
@@ -24,7 +24,7 @@ import { MyPoemsListComponent } from './my-poems-list/my-poems-list.component';
     HomeComponent,
     NavigationComponent,
     MyPoemsComponent,
-    MyPoemsEditDialogComponent,
+    MyPoemsEditDialog,
     MyPoemsListComponent,
   ],
   imports: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,8 @@ import {LoginButtonComponent} from './login-button/login-button.component';
 import {MaterialModule} from './material/material.module';
 import {MyPoemsComponent} from './my-poems/my-poems.component';
 import {NavigationComponent} from './navigation/navigation.component';
+import { MyPoemsEditDialogComponent } from './my-poems-edit-dialog/my-poems-edit-dialog.component';
+import { MyPoemsListComponent } from './my-poems-list/my-poems-list.component';
 
 @NgModule({
   declarations: [
@@ -22,6 +24,8 @@ import {NavigationComponent} from './navigation/navigation.component';
     HomeComponent,
     NavigationComponent,
     MyPoemsComponent,
+    MyPoemsEditDialogComponent,
+    MyPoemsListComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -9,6 +9,8 @@ import {CreateUserResponse} from './backend_response_types';
 @Injectable({providedIn: 'root'})
 export abstract class BaseBackendService {
   abstract createUser(email: string): Observable<CreateUserResponse>;
+  abstract createPoem(poemName: string, poemText: string, generated: boolean):
+      void;
 }
 
 @Injectable({providedIn: 'root'})
@@ -30,5 +32,9 @@ export class BackendService extends BaseBackendService {
     const endpoint = `${this.url}/api/create_user/${email}`;
     return this.http.get<CreateUserResponse>(endpoint).pipe(
         catchError(this.handleError<CreateUserResponse>('createUser')));
+  }
+
+  createPoem(poemName: string, poemText: string, generated: boolean): void {
+    // Not Yet Implemented
   }
 }

--- a/src/app/backend_response_types.ts
+++ b/src/app/backend_response_types.ts
@@ -14,3 +14,32 @@ export interface CreateUserResponse {
   created: boolean;
   user: User;
 }
+
+// Models a row the poem table
+export enum PoemPrivacyLevel {
+  public,
+  private,
+}
+
+export enum PoemForm {
+  haiku,
+  sonnet,
+  tonka,
+}
+
+export interface Poem {
+  // Note, a poem in the database should never have a null id
+  // a null id indicates that the object has not been saved to the database
+  id: number|null;
+
+  user_id: number;
+  creation_timestamp: Date|null;
+  modified_timestamp: Date|null;
+  privacy_level: PoemPrivacyLevel;
+  archived: boolean;
+  form: PoemForm;
+  generated: boolean;
+  text: string;
+  num_likes: number;
+  num_dislikes: number;
+}

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.css
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.css
@@ -6,3 +6,7 @@
 .poem-edit-form .poem-text-field {
     width: 100%;
 }
+
+.poem-edit-form button {
+    margin: 0px 5px;
+}

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.css
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.css
@@ -2,8 +2,7 @@
     width: 500px;
 }
 
-.poem-edit-form .poem-name-field,
-.poem-edit-form .poem-text-field {
+.poem-edit-form mat-form-field {
     width: 100%;
 }
 

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.css
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.css
@@ -1,0 +1,8 @@
+.poem-edit-form {
+    width: 500px;
+}
+
+.poem-edit-form .poem-name-field,
+.poem-edit-form .poem-text-field {
+    width: 100%;
+}

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.html
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.html
@@ -1,15 +1,15 @@
 <h1>Poem Editor</h1>
 <form class="poem-edit-form" autocomplete="off">
 
-    <mat-form-field class="poem-name-field" appearance="fill" floatLabel="always">
+    <mat-form-field appearance="fill" floatLabel="always">
         <mat-label>Poem Name</mat-label>
-        <input matInput required [(ngModel)]="poemName" [ngModelOptions]="{standalone: true}">
+        <input class="poem-name-field" matInput required [(ngModel)]="poemName" [ngModelOptions]="{standalone: true}">
     </mat-form-field>
 
-    <mat-form-field class="poem-text-field" appearance="fill" floatLabel="always">
+    <mat-form-field appearance="fill" floatLabel="always">
         <mat-label>Poem Text</mat-label>
-        <textarea matInput required cdkTextareaAutosize cdkAutosizeMinRows="5" [(ngModel)]=poemText
-            [ngModelOptions]="{standalone: true}"></textarea>
+        <textarea class="poem-text-field" matInput required cdkTextareaAutosize cdkAutosizeMinRows="5"
+            [(ngModel)]=poemText [ngModelOptions]="{standalone: true}"></textarea>
     </mat-form-field>
 
     <button class="poem-edit-submit" mat-flat-button color="primary" [disabled]="!canSubmit()"

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.html
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.html
@@ -1,19 +1,19 @@
 <h1>Poem Editor</h1>
-
 <form class="poem-edit-form" autocomplete="off">
-    <p>
-        <mat-form-field class="poem-name-field" appearance="fill" floatLabel="always">
-            <mat-label>Poem Name</mat-label>
-            <input matInput required #poemName>
-        </mat-form-field>
-    </p>
-    <p>
-        <mat-form-field class="poem-text-field" appearance="fill" floatLabel="always">
-            <mat-label>Poem Text</mat-label>
-            <textarea matInput required cdkTextareaAutosize cdkAutosizeMinRows="5" #poemText></textarea>
-        </mat-form-field>
-    </p>
-    <button mat-flat-button color="primary" [disabled]="!canSubmit(poemName.value, poemText.value)"
-        (click)="submit(poemName.value, poemText.value)">Submit</button>
-    <button mat-flat-button color="accent" (click)="cancel()">Cancel</button>
+
+    <mat-form-field class="poem-name-field" appearance="fill" floatLabel="always">
+        <mat-label>Poem Name</mat-label>
+        <input matInput required [(ngModel)]="poemName" [ngModelOptions]="{standalone: true}">
+    </mat-form-field>
+
+    <mat-form-field class="poem-text-field" appearance="fill" floatLabel="always">
+        <mat-label>Poem Text</mat-label>
+        <textarea matInput required cdkTextareaAutosize cdkAutosizeMinRows="5" [(ngModel)]=poemText
+            [ngModelOptions]="{standalone: true}"></textarea>
+    </mat-form-field>
+
+    <button class="poem-edit-submit" mat-flat-button color="primary" [disabled]="!canSubmit()"
+        (click)="submit()">Submit</button>
+
+    <button class="poem-edit-cancel" mat-flat-button color="accent" (click)="cancel()">Cancel</button>
 </form>

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.html
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.html
@@ -1,0 +1,1 @@
+<p>my-poems-edit-dialog works!</p>

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.html
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.html
@@ -1,1 +1,19 @@
-<p>my-poems-edit-dialog works!</p>
+<h1>Poem Editor</h1>
+
+<form class="poem-edit-form" autocomplete="off">
+    <p>
+        <mat-form-field class="poem-name-field" appearance="fill" floatLabel="always">
+            <mat-label>Poem Name</mat-label>
+            <input matInput required #poemName>
+        </mat-form-field>
+    </p>
+    <p>
+        <mat-form-field class="poem-text-field" appearance="fill" floatLabel="always">
+            <mat-label>Poem Text</mat-label>
+            <textarea matInput required cdkTextareaAutosize cdkAutosizeMinRows="5" #poemText></textarea>
+        </mat-form-field>
+    </p>
+    <button mat-flat-button color="primary" [disabled]="!canSubmit(poemName.value, poemText.value)"
+        (click)="submit(poemName.value, poemText.value)">Submit</button>
+    <button mat-flat-button color="accent" (click)="cancel()">Cancel</button>
+</form>

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
@@ -13,12 +13,12 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {BackendService} from '../backend.service';
 import {BackendServiceStub} from '../testing/backend-service-stub';
 
-import {MyPoemsEditDialogComponent} from './my-poems-edit-dialog.component';
+import {MyPoemsEditDialog} from './my-poems-edit-dialog.component';
 
-describe('MyPoemsEditDialogComponent', () => {
+describe('MyPoemsEditDialog', () => {
   let backendServiceStub: BackendServiceStub;
-  let component: MyPoemsEditDialogComponent;
-  let fixture: ComponentFixture<MyPoemsEditDialogComponent>;
+  let component: MyPoemsEditDialog;
+  let fixture: ComponentFixture<MyPoemsEditDialog>;
   let loader: HarnessLoader;
 
   beforeEach(async () => {
@@ -26,7 +26,7 @@ describe('MyPoemsEditDialogComponent', () => {
 
     await TestBed
         .configureTestingModule({
-          declarations: [MyPoemsEditDialogComponent],
+          declarations: [MyPoemsEditDialog],
           imports: [
             BrowserAnimationsModule,
             FormsModule,
@@ -44,7 +44,7 @@ describe('MyPoemsEditDialogComponent', () => {
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(MyPoemsEditDialogComponent);
+    fixture = TestBed.createComponent(MyPoemsEditDialog);
     component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
@@ -54,7 +54,7 @@ describe('MyPoemsEditDialogComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should disable the Submit button unless all fields are suplied',
+  it('should disable the Submit button unless all fields are supplied',
      async () => {
        const submitButton = await loader.getHarness(
            MatButtonHarness.with({selector: '.poem-edit-submit'}));

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MyPoemsEditDialogComponent } from './my-poems-edit-dialog.component';
+
+describe('MyPoemsEditDialogComponent', () => {
+  let component: MyPoemsEditDialogComponent;
+  let fixture: ComponentFixture<MyPoemsEditDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MyPoemsEditDialogComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MyPoemsEditDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
@@ -1,25 +1,111 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material/button';
+import {MatButtonHarness} from '@angular/material/button/testing';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatInputHarness} from '@angular/material/input/testing';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
-import { MyPoemsEditDialogComponent } from './my-poems-edit-dialog.component';
+import {BackendService} from '../backend.service';
+import {BackendServiceStub} from '../testing/backend-service-stub';
+
+import {MyPoemsEditDialogComponent} from './my-poems-edit-dialog.component';
 
 describe('MyPoemsEditDialogComponent', () => {
+  let backendServiceStub: BackendServiceStub;
   let component: MyPoemsEditDialogComponent;
   let fixture: ComponentFixture<MyPoemsEditDialogComponent>;
+  let loader: HarnessLoader;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ MyPoemsEditDialogComponent ]
-    })
-    .compileComponents();
+    backendServiceStub = new BackendServiceStub();
+
+    await TestBed
+        .configureTestingModule({
+          declarations: [MyPoemsEditDialogComponent],
+          imports: [
+            BrowserAnimationsModule,
+            FormsModule,
+            MatButtonModule,
+            MatFormFieldModule,
+            MatInputModule,
+          ],
+          providers: [
+            {provide: BackendService, useValue: backendServiceStub},
+            {provide: MatDialogRef, useValue: {close: (_: any) => null}},
+            {provide: MAT_DIALOG_DATA, useValue: {}},
+          ],
+        })
+        .compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyPoemsEditDialogComponent);
     component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should disable the Submit button unless all fields are suplied',
+     async () => {
+       const submitButton = await loader.getHarness(
+           MatButtonHarness.with({selector: '.poem-edit-submit'}));
+       const poemNameField = await loader.getHarness(
+           MatInputHarness.with({selector: '.poem-name-field'}));
+       const poemTextField = await loader.getHarness(
+           MatInputHarness.with({selector: '.poem-text-field'}));
+
+       // No inputs, button should be disabled
+       expect(await submitButton.isDisabled()).toBeTrue();
+
+       // Either one field has value, should be disabled
+       await poemNameField.setValue('test');
+       expect(await submitButton.isDisabled()).toBeTrue();
+
+       await poemNameField.setValue('');
+       await poemTextField.setValue('test');
+       expect(await submitButton.isDisabled()).toBeTrue();
+
+       // Both fields have value, should not be disabled
+       await poemNameField.setValue('test');
+       expect(await submitButton.isDisabled()).toBeFalse();
+     });
+
+  it('should not create the poem if Cancel is clicked', async () => {
+    spyOn(backendServiceStub, 'createPoem');
+
+    const cancelButton = await loader.getHarness(
+        MatButtonHarness.with({selector: '.poem-edit-cancel'}));
+    await cancelButton.click();
+
+    expect(backendServiceStub.createPoem).not.toHaveBeenCalled();
+  });
+
+  it('should should create the poem if Submit is clicked', async () => {
+    spyOn(backendServiceStub, 'createPoem');
+
+    const submitButton = await loader.getHarness(
+        MatButtonHarness.with({selector: '.poem-edit-submit'}));
+    const poemNameField = await loader.getHarness(
+        MatInputHarness.with({selector: '.poem-name-field'}));
+    const poemTextField = await loader.getHarness(
+        MatInputHarness.with({selector: '.poem-text-field'}));
+
+    const testName = 'testName';
+    const testPoem = 'testPoem';
+    await poemNameField.setValue(testName);
+    await poemTextField.setValue(testPoem);
+    await submitButton.click();
+
+    expect(backendServiceStub.createPoem)
+        .toHaveBeenCalledWith(testName, testPoem, false);
   });
 });

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
@@ -9,13 +9,13 @@ import {Poem} from '../backend_response_types';
   templateUrl: './my-poems-edit-dialog.component.html',
   styleUrls: ['./my-poems-edit-dialog.component.css']
 })
-export class MyPoemsEditDialogComponent {
+export class MyPoemsEditDialog {
   poemName = '';
   poemText = '';
 
   constructor(
       private backendService: BackendService,
-      public dialogRef: MatDialogRef<MyPoemsEditDialogComponent>,
+      public dialogRef: MatDialogRef<MyPoemsEditDialog>,
       @Inject(MAT_DIALOG_DATA) public data: Poem,
   ) {}
 

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-my-poems-edit-dialog',
+  templateUrl: './my-poems-edit-dialog.component.html',
+  styleUrls: ['./my-poems-edit-dialog.component.css']
+})
+export class MyPoemsEditDialogComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
@@ -1,4 +1,8 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, Inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {BackendService} from '../backend.service';
+
+import {Poem} from '../backend_response_types';
 
 @Component({
   selector: 'app-my-poems-edit-dialog',
@@ -6,15 +10,28 @@ import {Component, OnInit} from '@angular/core';
   styleUrls: ['./my-poems-edit-dialog.component.css']
 })
 export class MyPoemsEditDialogComponent {
-  submit(poemName: string, poemText: string): void {
-    console.log(poemName, poemText);
+  poemName = '';
+  poemText = '';
+
+  constructor(
+      private backendService: BackendService,
+      public dialogRef: MatDialogRef<MyPoemsEditDialogComponent>,
+      @Inject(MAT_DIALOG_DATA) public data: Poem,
+  ) {}
+
+  canSubmit(): boolean {
+    return (this.poemName.trim().length > 0) &&
+        (this.poemText.trim().length > 0);
   }
 
-  canSubmit(poemName: string, poemText: string): boolean {
-    return (poemName.trim().length > 0) && (poemText.trim().length > 0);
+  submit(): void {
+    if (this.canSubmit()) {
+      this.backendService.createPoem(this.poemName, this.poemText, false);
+    }
+    this.dialogRef.close();
   }
 
   cancel(): void {
-    console.log('canceling');
+    this.dialogRef.close();
   }
 }

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
@@ -1,15 +1,20 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'app-my-poems-edit-dialog',
   templateUrl: './my-poems-edit-dialog.component.html',
   styleUrls: ['./my-poems-edit-dialog.component.css']
 })
-export class MyPoemsEditDialogComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit(): void {
+export class MyPoemsEditDialogComponent {
+  submit(poemName: string, poemText: string): void {
+    console.log(poemName, poemText);
   }
 
+  canSubmit(poemName: string, poemText: string): boolean {
+    return (poemName.trim().length > 0) && (poemText.trim().length > 0);
+  }
+
+  cancel(): void {
+    console.log('canceling');
+  }
 }

--- a/src/app/my-poems-list/my-poems-list.component.css
+++ b/src/app/my-poems-list/my-poems-list.component.css
@@ -1,0 +1,3 @@
+.new-my-poems-card {
+    cursor: pointer;
+}

--- a/src/app/my-poems-list/my-poems-list.component.html
+++ b/src/app/my-poems-list/my-poems-list.component.html
@@ -1,1 +1,2 @@
-<p>my-poems-list works!</p>
+<h1>My Poems</h1>
+<button (click)="openEditDialog()">EDIT POEM</button>

--- a/src/app/my-poems-list/my-poems-list.component.html
+++ b/src/app/my-poems-list/my-poems-list.component.html
@@ -1,2 +1,3 @@
 <h1>My Poems</h1>
-<button (click)="openEditDialog()">EDIT POEM</button>
+
+<mat-card class="new-my-poems-card" (click)="openEditDialog()">New Poem</mat-card>

--- a/src/app/my-poems-list/my-poems-list.component.html
+++ b/src/app/my-poems-list/my-poems-list.component.html
@@ -1,0 +1,1 @@
+<p>my-poems-list works!</p>

--- a/src/app/my-poems-list/my-poems-list.component.spec.ts
+++ b/src/app/my-poems-list/my-poems-list.component.spec.ts
@@ -1,25 +1,67 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatCardModule} from '@angular/material/card';
+import {MatCardHarness} from '@angular/material/card/testing';
+import {MatDialog, MatDialogModule} from '@angular/material/dialog';
+import {MatDialogHarness} from '@angular/material/dialog/testing';
+import {BackendService} from '../backend.service';
+import {MyPoemsEditDialogComponent} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
+import {BackendServiceStub} from '../testing/backend-service-stub';
 
-import { MyPoemsListComponent } from './my-poems-list.component';
+import {MyPoemsListComponent} from './my-poems-list.component';
 
 describe('MyPoemsListComponent', () => {
+  let backendServiceStub: BackendServiceStub;
   let component: MyPoemsListComponent;
   let fixture: ComponentFixture<MyPoemsListComponent>;
+  let loader: HarnessLoader;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ MyPoemsListComponent ]
-    })
-    .compileComponents();
+    backendServiceStub = new BackendServiceStub();
+
+    await TestBed
+        .configureTestingModule({
+          imports: [
+            MatCardModule,
+            MatDialogModule,
+          ],
+          declarations: [MyPoemsListComponent],
+          providers: [
+            {provide: BackendService, useValue: backendServiceStub},
+          ],
+        })
+        .compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyPoemsListComponent);
     component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should open a new poem dialog', () => {
+    // Spy on the dialog's open call
+    const dialog = TestBed.inject(MatDialog);
+    spyOn(dialog, 'open');
+
+    // Click the card to attempt to add a new poem
+    const newPoemCard =
+        fixture.nativeElement.querySelector('.new-my-poems-card');
+    if (!newPoemCard) throw new Error('Failed to find New Poem card');
+    newPoemCard.click();
+    fixture.detectChanges();
+
+    // Check that the dialog open was called
+    expect(dialog.open)
+        .toHaveBeenCalledOnceWith(
+            MyPoemsEditDialogComponent,
+            {data: undefined},
+        );
   });
 });

--- a/src/app/my-poems-list/my-poems-list.component.spec.ts
+++ b/src/app/my-poems-list/my-poems-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MyPoemsListComponent } from './my-poems-list.component';
+
+describe('MyPoemsListComponent', () => {
+  let component: MyPoemsListComponent;
+  let fixture: ComponentFixture<MyPoemsListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MyPoemsListComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MyPoemsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/my-poems-list/my-poems-list.component.spec.ts
+++ b/src/app/my-poems-list/my-poems-list.component.spec.ts
@@ -6,7 +6,7 @@ import {MatCardHarness} from '@angular/material/card/testing';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
 import {MatDialogHarness} from '@angular/material/dialog/testing';
 import {BackendService} from '../backend.service';
-import {MyPoemsEditDialogComponent} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
+import {MyPoemsEditDialog} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
 import {BackendServiceStub} from '../testing/backend-service-stub';
 
 import {MyPoemsListComponent} from './my-poems-list.component';
@@ -60,7 +60,7 @@ describe('MyPoemsListComponent', () => {
     // Check that the dialog open was called
     expect(dialog.open)
         .toHaveBeenCalledOnceWith(
-            MyPoemsEditDialogComponent,
+            MyPoemsEditDialog,
             {data: undefined},
         );
   });

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -1,5 +1,6 @@
 import {Component} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
+import {firstValueFrom} from 'rxjs';
 import {Poem} from '../backend_response_types';
 import {MyPoemsEditDialogComponent} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
 
@@ -11,7 +12,11 @@ import {MyPoemsEditDialogComponent} from '../my-poems-edit-dialog/my-poems-edit-
 export class MyPoemsListComponent {
   constructor(public editDialog: MatDialog) {}
 
-  openEditDialog(poem?: Poem): void {
-    const dialogRef = this.editDialog.open(MyPoemsEditDialogComponent);
+  async openEditDialog(poem?: Poem): Promise<void> {
+    const dialogRef = this.editDialog.open(
+        MyPoemsEditDialogComponent,
+        {data: poem},
+    );
+    await firstValueFrom(dialogRef.afterClosed());
   }
 }

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -1,6 +1,5 @@
 import {Component} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
-import {firstValueFrom} from 'rxjs';
 import {Poem} from '../backend_response_types';
 import {MyPoemsEditDialogComponent} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
 
@@ -13,10 +12,9 @@ export class MyPoemsListComponent {
   constructor(public editDialog: MatDialog) {}
 
   async openEditDialog(poem?: Poem): Promise<void> {
-    const dialogRef = this.editDialog.open(
+    this.editDialog.open(
         MyPoemsEditDialogComponent,
         {data: poem},
     );
-    await firstValueFrom(dialogRef.afterClosed());
   }
 }

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {Poem} from '../backend_response_types';
-import {MyPoemsEditDialogComponent} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
+import {MyPoemsEditDialog} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
 
 @Component({
   selector: 'app-my-poems-list',
@@ -13,7 +13,7 @@ export class MyPoemsListComponent {
 
   async openEditDialog(poem?: Poem): Promise<void> {
     this.editDialog.open(
-        MyPoemsEditDialogComponent,
+        MyPoemsEditDialog,
         {data: poem},
     );
   }

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-my-poems-list',
+  templateUrl: './my-poems-list.component.html',
+  styleUrls: ['./my-poems-list.component.css']
+})
+export class MyPoemsListComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -1,15 +1,17 @@
-import { Component, OnInit } from '@angular/core';
+import {Component} from '@angular/core';
+import {MatDialog} from '@angular/material/dialog';
+import {Poem} from '../backend_response_types';
+import {MyPoemsEditDialogComponent} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
 
 @Component({
   selector: 'app-my-poems-list',
   templateUrl: './my-poems-list.component.html',
   styleUrls: ['./my-poems-list.component.css']
 })
-export class MyPoemsListComponent implements OnInit {
+export class MyPoemsListComponent {
+  constructor(public editDialog: MatDialog) {}
 
-  constructor() { }
-
-  ngOnInit(): void {
+  openEditDialog(poem?: Poem): void {
+    const dialogRef = this.editDialog.open(MyPoemsEditDialogComponent);
   }
-
 }

--- a/src/app/my-poems/my-poems.component.css
+++ b/src/app/my-poems/my-poems.component.css
@@ -1,7 +1,11 @@
-.my-poems-content {
+.my-poems-content,
+.my-poems-content mat-grid-list,
+.my-poems-content mat-grid-list mat-grid-tile {
     height: 100%;
 }
 
 .my-poems-content .my-poems-tile-content {
+    width: 100%;
     height: 100%;
+    text-align: center;
 }

--- a/src/app/my-poems/my-poems.component.html
+++ b/src/app/my-poems/my-poems.component.html
@@ -2,7 +2,7 @@
     <mat-grid-list cols="3">
         <mat-grid-tile>
             <div class="my-poems-tile-content">
-                <h1>My Poems</h1>
+                <app-my-poems-list></app-my-poems-list>
             </div>
         </mat-grid-tile>
         <mat-grid-tile>

--- a/src/app/my-poems/my-poems.component.spec.ts
+++ b/src/app/my-poems/my-poems.component.spec.ts
@@ -1,11 +1,15 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatCardModule} from '@angular/material/card';
+import {MatDialogModule} from '@angular/material/dialog';
 import {MatGridListModule} from '@angular/material/grid-list';
+import {MyPoemsListComponent} from '../my-poems-list/my-poems-list.component';
 
 import {MyPoemsComponent} from './my-poems.component';
 
 describe('MyPoemsComponent', () => {
+  let compiled: HTMLElement;
   let component: MyPoemsComponent;
   let fixture: ComponentFixture<MyPoemsComponent>;
   let loader: HarnessLoader;
@@ -14,15 +18,21 @@ describe('MyPoemsComponent', () => {
     await TestBed
         .configureTestingModule({
           imports: [
+            MatCardModule,
+            MatDialogModule,
             MatGridListModule,
           ],
-          declarations: [MyPoemsComponent],
+          declarations: [
+            MyPoemsComponent,
+            MyPoemsListComponent,
+          ],
         })
         .compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MyPoemsComponent);
+    compiled = fixture.nativeElement;
     component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
@@ -30,5 +40,10 @@ describe('MyPoemsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should contain a my poems list component', () => {
+    const myPoemsList = compiled.querySelector('app-my-poems-list');
+    expect(myPoemsList).toBeTruthy();
   });
 });

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -1,12 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import {Observable, of} from 'rxjs';
 import {BaseBackendService} from '../backend.service';
-import {CreateUserResponse} from '../backend_response_types';
-
-interface User {
-  id: number;
-  email: string;
-}
+import {CreateUserResponse, User} from '../backend_response_types';
 
 export class BackendServiceStub extends BaseBackendService {
   /* These properties replace the actual database tables for testing */

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -36,4 +36,8 @@ export class BackendServiceStub extends BaseBackendService {
       }
     });
   }
+
+  createPoem(poemName: string, poemText: string, generated: boolean) {
+    // Not yet implemented
+  }
 }


### PR DESCRIPTION
Create a dialog box that allows the user to enter a new poem's title and text.

Previously, the My Poems page was just a skeleton with no content.
Now, the page includes a button that will trigger a dialog where the user can enter a poem's title and text.
The dialog's Submit will attempt to call into the backend service to create a poem, however this part of the service has not yet been implemented so the poem won't actually be created.

The submit button will remain disabled until all fields have been filled.

Dialog button:
![image](https://user-images.githubusercontent.com/15317173/117723647-41b5fd00-b1a8-11eb-94b7-57a3c6449b98.png)

Dialog window:
![image](https://user-images.githubusercontent.com/15317173/117723671-4c709200-b1a8-11eb-9265-480de648fb30.png)

Added tests to:
-check that the dialog opens when clicking the button
-check that the Submit button remains disabled until all fields are filled in
-check that the Cancel button does not trigger a save
-check that the Submit button attempts to save the poem