### PR TITLE
Create poem backend service

### DIFF
--- a/sql/tables/poem.sql
+++ b/sql/tables/poem.sql
@@ -7,6 +7,7 @@ CREATE TABLE `poem` (
   `archived` bit(1) NOT NULL DEFAULT b'0',
   `form` enum('haiku','sonnet','tonka') DEFAULT NULL,
   `generated` bit(1) NOT NULL DEFAULT b'0',
+  `name` varchar(45) NOT NULL,
   `text` varchar(8000) NOT NULL,
   `num_likes` int NOT NULL DEFAULT '0',
   `num_dislikes` int NOT NULL DEFAULT '0',

--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -74,7 +74,7 @@ describe('BackendService', () => {
     // Make sure we called the correct endpoint
     const req = controller.expectOne(
         `${backendUrl}/api/create_poem/${authServiceStub.getUserEmail()}/${
-            expectedPoemName}/${expectedPoemText}/${generated}`);
+            expectedPoemName}/${expectedPoemText}/${generated ? 1 : 0}`);
     expect(req.request.method).toEqual('GET');
 
     // Respond with some test information

--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -60,7 +60,7 @@ describe('BackendService', () => {
 
   it('should create poems', () => {
     const expectedPoemName = 'testName';
-    const expectedPoemText = 'testText';
+    const expectedPoemText = 'test text\nsecond line';
     const generated = false;
 
     // Call the backend create_poem endpoint
@@ -72,10 +72,15 @@ describe('BackendService', () => {
         });
 
     // Make sure we called the correct endpoint
-    const req = controller.expectOne(
-        `${backendUrl}/api/create_poem/${authServiceStub.getUserEmail()}/${
-            expectedPoemName}/${expectedPoemText}/${generated ? 1 : 0}`);
-    expect(req.request.method).toEqual('GET');
+    const req = controller.expectOne(`${backendUrl}/api/create_poem`);
+    expect(req.request.method).toEqual('POST');
+
+    // Make sure the body has all the parameters
+    const body = req.request.body;
+    expect(body.userEmail).toEqual(authServiceStub.getUserEmail());
+    expect(body.poemName).toEqual(expectedPoemName);
+    expect(body.poemText).toEqual(expectedPoemText);
+    expect(body.generated).toEqual(generated);
 
     // Respond with some test information
     const resp: CreatePoemResponse = {

--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -2,17 +2,25 @@ import {HttpClientTestingModule, HttpTestingController} from '@angular/common/ht
 import {TestBed} from '@angular/core/testing';
 
 import {environment} from '../environments/environment';
+import {AuthService} from './auth.service';
 
 import {BackendService} from './backend.service';
-import {CreateUserResponse} from './backend_response_types';
+import {CreatePoemResponse, CreateUserResponse, PoemForm, PoemPrivacyLevel} from './backend_response_types';
+import {AuthServiceStub} from './testing/auth-service-stub';
 
 describe('BackendService', () => {
-  let service: BackendService;
+  let authServiceStub: AuthServiceStub;
   let controller: HttpTestingController;
+  let service: BackendService;
   const backendUrl = environment.backend_url;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({imports: [HttpClientTestingModule]});
+    authServiceStub = new AuthServiceStub();
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{provide: AuthService, useValue: authServiceStub}],
+    });
     controller = TestBed.inject(HttpTestingController);
     service = TestBed.inject(BackendService);
   });
@@ -42,6 +50,49 @@ describe('BackendService', () => {
       'user': {
         'id': 1,
         'email': expectedEmail,
+      },
+    };
+    req.flush(resp);
+
+    // Assert there are no extra requests
+    controller.verify();
+  });
+
+  it('should create poems', () => {
+    const expectedPoemName = 'testName';
+    const expectedPoemText = 'testText';
+    const generated = false;
+
+    // Call the backend create_poem endpoint
+    service.createPoem(expectedPoemName, expectedPoemText, generated)
+        .subscribe((response: CreatePoemResponse) => {
+          expect(response.created).toBeTrue();
+          expect(response.poem.text).toEqual(expectedPoemText);
+          expect(response.poem.name).toEqual(expectedPoemName);
+        });
+
+    // Make sure we called the correct endpoint
+    const req = controller.expectOne(
+        `${backendUrl}/api/create_poem/${authServiceStub.getUserEmail()}/${
+            expectedPoemName}/${expectedPoemText}/${generated}`);
+    expect(req.request.method).toEqual('GET');
+
+    // Respond with some test information
+    const resp: CreatePoemResponse = {
+      'created': true,
+      'poem': {
+        'id': 1,
+        'user_id': 1,
+        'creation_timestamp': new Date(),
+        'modified_timestamp': null,
+        'privacy_level': PoemPrivacyLevel.public,
+        'archived': true,
+        'form': PoemForm.haiku,
+        'generated': generated,
+        'name': expectedPoemName,
+        'text': expectedPoemText,
+        'num_likes': 0,
+        'num_dislikes': 0,
       },
     };
     req.flush(resp);

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -47,7 +47,7 @@ export class BackendService extends BaseBackendService {
 
     // User has been identified, create a poem for them
     const endpoint = `${this.url}/api/create_poem/${userEmail}/${poemName}/${
-        poemText}/${generated}`;
+        poemText}/${generated ? 1 : 0}`;
     return this.http.get<CreatePoemResponse>(endpoint).pipe(
         catchError(this.handleError<CreatePoemResponse>('createPoem')));
   }

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -45,6 +45,11 @@ export class BackendService extends BaseBackendService {
     if (!userEmail)
       throw new Error('A user must be logged in before a poem can be createad');
 
+    // Replace new lines in poem text so that it encodes correctly.
+    // Also trim whitespace
+    poemName = poemName.trim();
+    poemText = poemText.trim().replace('\n', '%0A');
+
     // User has been identified, create a poem for them
     const endpoint = `${this.url}/api/create_poem/${userEmail}/${poemName}/${
         poemText}/${generated ? 1 : 0}`;

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -4,20 +4,24 @@ import {Observable, of} from 'rxjs';
 import {catchError} from 'rxjs/operators';
 
 import {environment} from '../environments/environment';
-import {CreateUserResponse} from './backend_response_types';
+import {AuthService} from './auth.service';
+import {CreatePoemResponse, CreateUserResponse} from './backend_response_types';
 
 @Injectable({providedIn: 'root'})
 export abstract class BaseBackendService {
   abstract createUser(email: string): Observable<CreateUserResponse>;
   abstract createPoem(poemName: string, poemText: string, generated: boolean):
-      void;
+      Observable<CreatePoemResponse>;
 }
 
 @Injectable({providedIn: 'root'})
 export class BackendService extends BaseBackendService {
   private url = environment.backend_url;
 
-  constructor(private http: HttpClient) {
+  constructor(
+      private auth: AuthService,
+      private http: HttpClient,
+  ) {
     super();
   }
 
@@ -34,7 +38,17 @@ export class BackendService extends BaseBackendService {
         catchError(this.handleError<CreateUserResponse>('createUser')));
   }
 
-  createPoem(poemName: string, poemText: string, generated: boolean): void {
-    // Not Yet Implemented
+  createPoem(poemName: string, poemText: string, generated: boolean):
+      Observable<CreatePoemResponse> {
+    // There must be a user logged in to associate with the new poem
+    const userEmail: string|undefined = this.auth.getUserEmail();
+    if (!userEmail)
+      throw new Error('A user must be logged in before a poem can be createad');
+
+    // User has been identified, create a poem for them
+    const endpoint = `${this.url}/api/create_poem/${userEmail}/${poemName}/${
+        poemText}/${generated}`;
+    return this.http.get<CreatePoemResponse>(endpoint).pipe(
+        catchError(this.handleError<CreatePoemResponse>('createPoem')));
   }
 }

--- a/src/app/backend_response_types.ts
+++ b/src/app/backend_response_types.ts
@@ -9,11 +9,12 @@ export interface User {
   email: string;
 }
 
-// Models the response for the /db/create_user/<email> endpoint
+// Models the response for the /api/create_user/<email> endpoint
 export interface CreateUserResponse {
   created: boolean;
   user: User;
 }
+
 
 // Models a row the poem table
 export enum PoemPrivacyLevel {
@@ -39,7 +40,14 @@ export interface Poem {
   archived: boolean;
   form: PoemForm;
   generated: boolean;
+  name: string;
   text: string;
   num_likes: number;
   num_dislikes: number;
+}
+
+// Models the response for the /api/create_user/<email> endpoint
+export interface CreatePoemResponse {
+  created: boolean;
+  poem: Poem;
 }

--- a/src/app/backend_response_types.ts
+++ b/src/app/backend_response_types.ts
@@ -29,10 +29,7 @@ export enum PoemForm {
 }
 
 export interface Poem {
-  // Note, a poem in the database should never have a null id
-  // a null id indicates that the object has not been saved to the database
-  id: number|null;
-
+  id: number;
   user_id: number;
   creation_timestamp: Date|null;
   modified_timestamp: Date|null;

--- a/src/app/login-button/login-button.component.ts
+++ b/src/app/login-button/login-button.component.ts
@@ -27,6 +27,7 @@ export class LoginButtonComponent {
             await firstValueFrom(this.backendService.createUser(userEmail));
 
         if (!response) {
+          console.log('bad response:', response);
           console.error(
               'Failed to get a response from the backend for creating a user');
         } else {

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
@@ -1,5 +1,6 @@
 import {Component, Inject} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {firstValueFrom} from 'rxjs';
 import {BackendService} from '../backend.service';
 
 import {Poem} from '../backend_response_types';
@@ -24,9 +25,15 @@ export class MyPoemsEditDialog {
         (this.poemText.trim().length > 0);
   }
 
-  submit(): void {
+  async submit(): Promise<void> {
     if (this.canSubmit()) {
-      this.backendService.createPoem(this.poemName, this.poemText, false);
+      const response = await firstValueFrom(
+          this.backendService.createPoem(this.poemName, this.poemText, false));
+
+      if (!response) {
+        throw new Error(
+            'Failed to get a response from the backend for creating a poem');
+      }
     }
     this.dialogRef.close();
   }

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -13,6 +13,7 @@ export class BackendServiceStub extends BaseBackendService {
 
     // Initialize fake tables with testing data
     this.user = [{'id': 1, 'email': 'user@gmail.com'}];
+    this.poem = [];
   }
 
   createUser(email: string): Observable<CreateUserResponse> {

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import {Observable, of} from 'rxjs';
 import {BaseBackendService} from '../backend.service';
-import {CreateUserResponse, User} from '../backend_response_types';
+import {CreatePoemResponse, CreateUserResponse, Poem, PoemForm, PoemPrivacyLevel, User} from '../backend_response_types';
 
 export class BackendServiceStub extends BaseBackendService {
   /* These properties replace the actual database tables for testing */
   user: User[];
+  poem: Poem[];
 
   constructor() {
     super();
@@ -37,7 +38,32 @@ export class BackendServiceStub extends BaseBackendService {
     });
   }
 
-  createPoem(poemName: string, poemText: string, generated: boolean) {
-    // Not yet implemented
+  createPoem(poemName: string, poemText: string, generated: boolean):
+      Observable<CreatePoemResponse> {
+    if (!this.user.length) {
+      throw new Error('No user to create poem for');
+    }
+
+    const newPoem: Poem = {
+      'id': Math.max(...this.poem.map(p => p.id)) + 1,
+      'user_id': this.user[0].id,
+      'creation_timestamp': new Date(),
+      'modified_timestamp': null,
+      'privacy_level': PoemPrivacyLevel.public,
+      'archived': true,
+      'form': PoemForm.haiku,
+      'generated': generated,
+      'name': poemName,
+      'text': poemText,
+      'num_likes': 0,
+      'num_dislikes': 0,
+    };
+
+    this.poem.push(newPoem);
+
+    return of({
+      'created': true,
+      'poem': newPoem,
+    });
   }
 }


### PR DESCRIPTION
Implement function in the backend service that will call into a flask endpoint to create poems.

Previously, the function in the backend service to create poems was not implemented.
Now, the function will call into the flask endpoint at `/api/create_poem/<userEmail>/<poemName>/<poemText>/<generated>` to create a poem.

Note: the flask endpoint at that route has not yet been implemented.

Added tests to:
- check that the backend service calls the correct create_poem flask endpoint