### PR TITLE
Get manually written poems

### DIFF
--- a/api.py
+++ b/api.py
@@ -59,7 +59,7 @@ def create_poem():
 @blueprint.route('/get_poems/<any(best, new):poem_type>/<int:num_poems>',
                  defaults={'user_email': None})
 @blueprint.route(
-    '/get_poems/<any(manual, generated):poem_type>/<int:num_poems>/<user_email>'
+    '/get_poems/<any(manual, liked, generated):poem_type>/<int:num_poems>/<user_email>'
 )
 def get_poems(poem_type, num_poems, user_email):
     """Retreives poems
@@ -69,6 +69,7 @@ def get_poems(poem_type, num_poems, user_email):
             best: returns poem with the highest likes - dislikes
             new: returns poems with the most recent creation timestamp
             manual: returns poems that the user manually wrote
+            liked: returns poems the user has liked
             generated: returns poems that the user generated
         num_poems (int): the number of poems to retrieve. 0 returns all poems
         user_email (string): The email of the user to retrieve poems for.
@@ -121,6 +122,10 @@ def get_poems(poem_type, num_poems, user_email):
         if num_poems > 0:
             query = query.limit(num_poems)
         poems = query.all()
+
+    elif poem_type == 'liked':
+        raise NotImplementedError(
+            'Retrieving liked poems has not yet been implemented')
 
     elif poem_type == 'generated':
         raise NotImplementedError(

--- a/api.py
+++ b/api.py
@@ -113,12 +113,13 @@ def get_poems(poem_type, num_poems, user_email):
             'Retrieving newest poems has not yet been implemented')
 
     elif poem_type == 'manual':
-        query = models.Poem.query.filter_by(user_id=user.id, generated=False)
-        if num_poems > 0:
-            query = query.order_by(
+        query = models.Poem.query.filter_by(
+            user_id=user.id, generated=False).order_by(
                 models.Poem.modified_timestamp.desc(),
                 models.Poem.creation_timestamp.desc(),
-            ).limit(num_poems)
+            )
+        if num_poems > 0:
+            query = query.limit(num_poems)
         poems = query.all()
 
     elif poem_type == 'generated':

--- a/api.py
+++ b/api.py
@@ -39,7 +39,7 @@ def create_poem():
     poem_text = body['poemText']
     generated = body['generated']
 
-    # check that the user exists
+    # Check that the user exists
     user = models.User.query.filter_by(email=user_email).first()
     if not user:
         raise ValueError(f'Failed to find a user with email: {user_email}')
@@ -53,4 +53,81 @@ def create_poem():
     db.session.commit()
 
     result = {'created': True, 'poem': poem}
+    return json.dumps(result, cls=models.ModelEncoder)
+
+
+@blueprint.route('/get_poems/<any(best, new):poem_type>/<int:num_poems>',
+                 defaults={'user_email': None})
+@blueprint.route(
+    '/get_poems/<any(manual, generated):poem_type>/<int:num_poems>/<user_email>'
+)
+def get_poems(poem_type, num_poems, user_email):
+    """Retreives poems
+
+    Args:
+        poem_type (string): one of best, new, manual, or generated
+            best: returns poem with the highest likes - dislikes
+            new: returns poems with the most recent creation timestamp
+            manual: returns poems that the user manually wrote
+            generated: returns poems that the user generated
+        num_poems (int): the number of poems to retrieve. 0 returns all poems
+        user_email (string): The email of the user to retrieve poems for.
+            Ignored for poem types best and new.
+
+    Returns:
+        string: json string for a dictionary with keys for.
+            type (string): the type the user queried for with poem_type
+            poems (list): a list of poems retrieved form the database.
+                Each poem is a dictionary:
+                {
+                    id: int,
+                    user_id: int,
+                    creation_timestamp: datetime|null,
+                    modified_timestamp: datetime|null,
+                    privacy_level: enum(Public, Private),
+                    archived: boolean,
+                    form: enum(Haiku, Sonent, Tonka)|null,
+                    generated: boolean,
+                    name: string,
+                    text: string,
+                    num_likes: number,
+                    num_dislikes: number,
+                }
+                Poems are ordered by most recently modified then created
+    """
+
+    # Check that the user exists if the poem type requires a user
+    user = None
+    if user_email:
+        user = models.User.query.filter_by(email=user_email).first()
+        if not user:
+            raise ValueError(f'Failed to find a user with email: {user_email}')
+
+    # Query the database based on the poem type
+    if poem_type == 'best':
+        raise NotImplementedError(
+            'Retrieving best poems has not yet been implemented')
+
+    elif poem_type == 'new':
+        raise NotImplementedError(
+            'Retrieving newest poems has not yet been implemented')
+
+    elif poem_type == 'manual':
+        query = models.Poem.query.filter_by(user_id=user.id, generated=False)
+        if num_poems > 0:
+            query = query.order_by(
+                models.Poem.modified_timestamp.desc(),
+                models.Poem.creation_timestamp.desc(),
+            ).limit(num_poems)
+        poems = query.all()
+
+    elif poem_type == 'generated':
+        raise NotImplementedError(
+            'Retrieving generated poems has not yet been implemented')
+
+    else:
+        raise ValueError(
+            'Poem type must be one of best, new, manual, or generated')
+
+    result = {'type': poem_type, 'poems': poems}
     return json.dumps(result, cls=models.ModelEncoder)

--- a/api_test.py
+++ b/api_test.py
@@ -1,6 +1,7 @@
 """Tests for db.py"""
 import json
 from absl.testing import absltest
+from datetime import datetime, timedelta
 from flask_webtest import TestApp
 
 from app import app
@@ -41,6 +42,28 @@ class DbTest(absltest.TestCase):
         db.session.execute(wipe_user_sql)
         db.session.commit()
 
+    def populate_user_data(self):
+        user = models.User(email=self.test_email)
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+    def populate_poem_data(self, user_id, generated, num_poems=1):
+        results = []
+        for i in range(num_poems):
+            poem = models.Poem(
+                user_id=user_id,
+                creation_timestamp=(datetime.now() -
+                                    timedelta(minutes=num_poems - i)),
+                generated=generated,
+                name=f'test poem {i}',
+                text=f'poem {i}\ntest\ntext',
+            )
+            db.session.add(poem)
+            results.append(poem)
+        db.session.commit()
+        return results
+
     @with_app_context
     def test_create_user(self):
         first_create = self.w.get(f'/api/create_user/{self.test_email}')
@@ -61,9 +84,7 @@ class DbTest(absltest.TestCase):
     @with_app_context
     def test_create_poem(self):
         # First create user to associate the poem with
-        user = models.User(email=self.test_email)
-        db.session.add(user)
-        db.session.flush()
+        user = self.populate_user_data()
 
         # Call the endpoint
         poem_name = 'test poem'
@@ -106,6 +127,39 @@ class DbTest(absltest.TestCase):
 
         with self.assertRaises(ValueError) as context:
             self.w.post_json('/api/create_poem', request_body)
+        self.assertTrue(
+            'Failed to find a user with email' in str(context.exception))
+
+    @with_app_context
+    def test_get_manual_poems(self):
+        # First create the user to associate poems with
+        user = self.populate_user_data()
+
+        # Create some poems to query for
+        num_poems = 4
+        all_poems = self.populate_poem_data(user.id, False, num_poems)
+        all_poems.sort(
+            key=lambda p: p.modified_timestamp or p.creation_timestamp)
+
+        # Query for all the manual poems
+        get = self.w.get(f'/api/get_poems/manual/0/{user.email}')
+        get_resp = json.loads(get.body)
+        self.assertEqual(get_resp['type'], 'manual')
+
+        all_manual_poems = get_resp['poems']
+        self.assertEqual(len(all_manual_poems), len(all_poems))
+        for i in range(num_poems):
+            poem = all_poems[i]
+            manual_poem = all_manual_poems[i]
+            self.assertEqual(poem.name, manual_poem['name'])
+            self.assertEqual(poem.text, manual_poem['text'])
+            self.assertEqual(manual_poem['generated'], False)
+            self.assertEqual(manual_poem['user_id'], user.id)
+
+    @with_app_context
+    def test_get_manual_poems_error(self):
+        with self.assertRaises(ValueError) as context:
+            self.w.get(f'/api/get_poems/manual/0/{self.test_email}')
         self.assertTrue(
             'Failed to find a user with email' in str(context.exception))
 

--- a/api_test.py
+++ b/api_test.py
@@ -143,6 +143,7 @@ class DbTest(absltest.TestCase):
             reverse=True)
 
         # Query for all the manual poems
+        url = f'/api/get_poems/manual/0/{user.email}'
         get = self.w.get(f'/api/get_poems/manual/0/{user.email}')
         get_resp = json.loads(get.body)
         self.assertEqual(get_resp['type'], 'manual')
@@ -164,20 +165,21 @@ class DbTest(absltest.TestCase):
 
         # Create some poems to query for
         num_poems = 4
+        half_num_poems = num_poems // 2
         all_poems = self.populate_poem_data(user.id, False, num_poems)
         all_poems.sort(
             key=lambda p: p.modified_timestamp or p.creation_timestamp,
             reverse=True)
 
         # Query some of the poems
-        get_partial = self.w.get(
-            f'/api/get_poems/manual/{num_poems//2}/{user.email}')
+        url = f'/api/get_poems/manual/{half_num_poems}/{user.email}'
+        get_partial = self.w.get(url)
         get_partial_resp = json.loads(get_partial.body)
         self.assertEqual(get_partial_resp['type'], 'manual')
 
         some_manual_poems = get_partial_resp['poems']
-        self.assertEqual(len(some_manual_poems), num_poems // 2)
-        for i in range(num_poems // 2):
+        self.assertEqual(len(some_manual_poems), half_num_poems)
+        for i in range(half_num_poems):
             poem = all_poems[i]
             manual_poem = some_manual_poems[i]
             self.assertEqual(poem.name, manual_poem['name'])
@@ -188,7 +190,8 @@ class DbTest(absltest.TestCase):
     @with_app_context
     def test_get_manual_poems_error(self):
         with self.assertRaises(ValueError) as context:
-            self.w.get(f'/api/get_poems/manual/0/{self.test_email}')
+            url = f'/api/get_poems/manual/0/{self.test_email}'
+            self.w.get(url)
         self.assertTrue(
             'Failed to find a user with email' in str(context.exception))
 

--- a/sql/tables/poem.sql
+++ b/sql/tables/poem.sql
@@ -3,10 +3,10 @@ CREATE TABLE `poem` (
   `user_id` int NOT NULL,
   `creation_timestamp` datetime NOT NULL,
   `modified_timestamp` datetime DEFAULT NULL,
-  `privacy_level` enum('public','private') NOT NULL DEFAULT 'public',
-  `archived` bit(1) NOT NULL DEFAULT b'0',
-  `form` enum('haiku','sonnet','tonka') DEFAULT NULL,
-  `generated` bit(1) NOT NULL DEFAULT b'0',
+  `privacy_level` enum('PUBLIC','PRIVATE') NOT NULL DEFAULT 'PUBLIC',
+  `archived` tinyint NOT NULL DEFAULT '0',
+  `form` enum('HAIKU','SONNET','TONKA') DEFAULT NULL,
+  `generated` tinyint NOT NULL DEFAULT '0',
   `name` varchar(45) NOT NULL,
   `text` varchar(8000) NOT NULL,
   `num_likes` int NOT NULL DEFAULT '0',
@@ -15,4 +15,4 @@ CREATE TABLE `poem` (
   UNIQUE KEY `id_UNIQUE` (`id`),
   KEY `user_fk_idx` (`user_id`),
   CONSTRAINT `user_fk` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=66 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
Create an endpoint to retrieve manually written poems.

Previously, the app had no way to retrieve poems stored in the database. Now, there is an endpoint at `api/get_poems/manual/<num_poems>/<user_email>` to retrieve a list of at most `num_poems` manually written poems for the user with the provided email.
If no user exists, an error is returned. If `num_poems` is 0, all manually written poems for the user are returned.

Note: endpoints also exist for retrieving the best, newest, and generated poems but they are currently not implemented.

Added tests to:
- check that the endpoint retrieves all manually written poems for a user
- check that the endpoint retrieves `num_poems` number of manually written poems
- check that the endpoint throws an error if the specified user doesn't exist