### PR TITLE
Get poems backend service

### DIFF
--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -110,7 +110,7 @@ describe('BackendService', () => {
     const num_poems_to_get = 5;
 
     // Call the backend create_poem endpoint
-    service.manualPoemsObservable.subscribe(
+    service.manualPoemsObservable$.subscribe(
         poems => expect(poems.length).toBeLessThanOrEqual(num_poems_to_get));
     service.getManualPoems(num_poems_to_get);
 

--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -5,7 +5,7 @@ import {environment} from '../environments/environment';
 import {AuthService} from './auth.service';
 
 import {BackendService} from './backend.service';
-import {CreatePoemResponse, CreateUserResponse, PoemForm, PoemPrivacyLevel} from './backend_response_types';
+import {CreatePoemResponse, CreateUserResponse, GetPoemsResponse, PoemForm, PoemPrivacyLevel} from './backend_response_types';
 import {AuthServiceStub} from './testing/auth-service-stub';
 
 describe('BackendService', () => {
@@ -99,6 +99,43 @@ describe('BackendService', () => {
         'num_likes': 0,
         'num_dislikes': 0,
       },
+    };
+    req.flush(resp);
+
+    // Assert there are no extra requests
+    controller.verify();
+  });
+
+  it('should retrieve manually written poems', () => {
+    const num_poems_to_get = 5;
+
+    // Call the backend create_poem endpoint
+    service.manualPoemsObservable.subscribe(
+        poems => expect(poems.length).toBeLessThanOrEqual(num_poems_to_get));
+    service.getManualPoems(num_poems_to_get);
+
+    // Make sure we called the correct endpoint
+    const req = controller.expectOne(`${backendUrl}/api/get_poems/manual/${
+        num_poems_to_get}/${authServiceStub.getUserEmail()}`);
+    expect(req.request.method).toEqual('GET');
+
+    // Respond with some test information
+    const resp: GetPoemsResponse = {
+      'type': 'manual',
+      'poems': [{
+        'id': 1,
+        'user_id': 1,
+        'creation_timestamp': new Date(),
+        'modified_timestamp': null,
+        'privacy_level': PoemPrivacyLevel.Public,
+        'archived': true,
+        'form': null,
+        'generated': false,
+        'name': 'test name',
+        'text': 'test text',
+        'num_likes': 0,
+        'num_dislikes': 0,
+      }],
     };
     req.flush(resp);
 

--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -110,7 +110,7 @@ describe('BackendService', () => {
     const num_poems_to_get = 5;
 
     // Call the backend create_poem endpoint
-    service.manualPoemsObservable$.subscribe(
+    service.manualPoems$.subscribe(
         poems => expect(poems.length).toBeLessThanOrEqual(num_poems_to_get));
     service.getManualPoems(num_poems_to_get);
 

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -5,17 +5,23 @@ import {catchError, map, switchAll} from 'rxjs/operators';
 
 import {environment} from '../environments/environment';
 import {AuthService} from './auth.service';
-import {CreatePoemResponse, CreateUserResponse, GetPoemsResponse, Poem} from './backend_response_types';
+import {CreatePoemResponse, CreateUserResponse, GetPoemsResponse} from './backend_response_types';
 
 @Injectable({providedIn: 'root'})
 export abstract class BaseBackendService {
+  // Observables and subjects for the various types of poems
   protected manualPoemsSubject = new Subject<Observable<GetPoemsResponse>>();
   readonly manualPoemsObservable = this.manualPoemsSubject.pipe(
       switchAll(), map(response => response.poems));
 
+  // Functions to create new information. The backend will create new rows in
+  // the database
   abstract createUser(email: string): Observable<CreateUserResponse>;
   abstract createPoem(poemName: string, poemText: string, generated: boolean):
       Observable<CreatePoemResponse>;
+
+  // Functions that trigger an update to a poem observable
+  abstract getManualPoems(numPoems: number): void;
 }
 
 @Injectable({providedIn: 'root'})
@@ -67,7 +73,7 @@ export class BackendService extends BaseBackendService {
         .pipe(catchError(this.handleError<CreatePoemResponse>('createPoem')));
   }
 
-  public getManualPoems(numPoems = 0): void {
+  getManualPoems(numPoems = 0): void {
     this.manualPoemsSubject.next(this._getPoemsRequest('manual', numPoems));
   }
 

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -1,7 +1,7 @@
 import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Observable, of, Subject} from 'rxjs';
-import {catchError, map, switchAll} from 'rxjs/operators';
+import {catchError, map, shareReplay, switchAll} from 'rxjs/operators';
 
 import {environment} from '../environments/environment';
 import {AuthService} from './auth.service';
@@ -11,8 +11,8 @@ import {CreatePoemResponse, CreateUserResponse, GetPoemsResponse} from './backen
 export abstract class BaseBackendService {
   // Observables and subjects for the various types of poems
   protected manualPoemsSubject = new Subject<Observable<GetPoemsResponse>>();
-  readonly manualPoemsObservable = this.manualPoemsSubject.pipe(
-      switchAll(), map(response => response.poems));
+  readonly manualPoemsObservable$ = this.manualPoemsSubject.pipe(
+      switchAll(), map(response => response.poems), shareReplay());
 
   // Functions to create new information. The backend will create new rows in
   // the database

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -1,14 +1,18 @@
 import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {Observable, of} from 'rxjs';
-import {catchError} from 'rxjs/operators';
+import {Observable, of, Subject} from 'rxjs';
+import {catchError, map, switchAll} from 'rxjs/operators';
 
 import {environment} from '../environments/environment';
 import {AuthService} from './auth.service';
-import {CreatePoemResponse, CreateUserResponse} from './backend_response_types';
+import {CreatePoemResponse, CreateUserResponse, GetPoemsResponse, Poem} from './backend_response_types';
 
 @Injectable({providedIn: 'root'})
 export abstract class BaseBackendService {
+  protected manualPoemsSubject = new Subject<Observable<GetPoemsResponse>>();
+  readonly manualPoemsObservable = this.manualPoemsSubject.pipe(
+      switchAll(), map(response => response.poems));
+
   abstract createUser(email: string): Observable<CreateUserResponse>;
   abstract createPoem(poemName: string, poemText: string, generated: boolean):
       Observable<CreatePoemResponse>;
@@ -61,5 +65,32 @@ export class BackendService extends BaseBackendService {
     return this.http
         .post<CreatePoemResponse>(endpoint, requestBody, this.httpOptions)
         .pipe(catchError(this.handleError<CreatePoemResponse>('createPoem')));
+  }
+
+  public getManualPoems(numPoems = 0): void {
+    this.manualPoemsSubject.next(this._getPoemsRequest('manual', numPoems));
+  }
+
+  protected _getPoemsRequest(poemType: string, numPoems: number):
+      Observable<GetPoemsResponse> {
+    let endpoint = `${this.url}/api/get_poems/${poemType}/${numPoems}`;
+    const userEmail: string|undefined = this.auth.getUserEmail();
+
+    if (poemType === 'manual') {
+      // There must be a user logged in to retrieve poems for
+      if (!userEmail)
+        throw new Error(
+            'A user must be logged in before a poems can be retrieved');
+
+      endpoint = `${endpoint}/${userEmail}`;
+      return this.http.get<GetPoemsResponse>(endpoint).pipe(
+          catchError(this.handleError<GetPoemsResponse>('getPoems')));
+    } else if (
+        poemType === 'best' || poemType === 'new' || poemType === 'generated') {
+      throw new Error(
+          `Retrieving poems not yet implemented for ${poemType} poems`);
+    } else {
+      throw new Error(`Unrecognized poem type: ${poemType}`);
+    }
   }
 }

--- a/src/app/backend_response_types.ts
+++ b/src/app/backend_response_types.ts
@@ -35,7 +35,7 @@ export interface Poem {
   modified_timestamp: Date|null;
   privacy_level: PoemPrivacyLevel;
   archived: boolean;
-  form: PoemForm;
+  form: PoemForm|null;
   generated: boolean;
   name: string;
   text: string;

--- a/src/app/backend_response_types.ts
+++ b/src/app/backend_response_types.ts
@@ -48,3 +48,10 @@ export interface CreatePoemResponse {
   created: boolean;
   poem: Poem;
 }
+
+// Models the response for the /api/get_poems/<poemType>/<numPoems>/<email?>
+// endpoint
+export interface GetPoemsResponse {
+  type: string;
+  poems: Poem[];
+}

--- a/src/app/login-button/login-button.component.spec.ts
+++ b/src/app/login-button/login-button.component.spec.ts
@@ -5,6 +5,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatButtonHarness} from '@angular/material/button/testing';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatProgressSpinnerHarness} from '@angular/material/progress-spinner/testing';
+import {of} from 'rxjs';
 
 import {AuthService} from '../auth.service';
 import {BackendService} from '../backend.service';
@@ -106,7 +107,10 @@ describe('LoginButtonComponent', () => {
     if (!expectedEmail)
       throw new Error('Auth service stub did not have an email configured');
     authServiceStub.clearUser();
-    spyOn(backendServiceStub, 'createUser');
+
+    // Set up spy for backend stub
+    const spyResponse = backendServiceStub.createUser(expectedEmail);
+    spyOn(backendServiceStub, 'createUser').and.returnValue(spyResponse);
 
     const logInButton = await loader.getHarness(
         MatButtonHarness.with({selector: '.login-button'}));

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatInputHarness} from '@angular/material/input/testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {of} from 'rxjs';
 
 import {BackendService} from '../backend.service';
 import {BackendServiceStub} from '../testing/backend-service-stub';
@@ -80,7 +81,9 @@ describe('MyPoemsEditDialog', () => {
      });
 
   it('should not create the poem if Cancel is clicked', async () => {
-    spyOn(backendServiceStub, 'createPoem');
+    // Set up backend service spy
+    const spyResponse = backendServiceStub.createPoem('test', 'test', false);
+    spyOn(backendServiceStub, 'createPoem').and.returnValue(spyResponse);
 
     const cancelButton = await loader.getHarness(
         MatButtonHarness.with({selector: '.poem-edit-cancel'}));
@@ -90,7 +93,13 @@ describe('MyPoemsEditDialog', () => {
   });
 
   it('should should create the poem if Submit is clicked', async () => {
-    spyOn(backendServiceStub, 'createPoem');
+    const testName = 'testName';
+    const testPoem = 'testPoem';
+
+    // Set up backend service spy
+    const spyResponse =
+        backendServiceStub.createPoem(testName, testPoem, false);
+    spyOn(backendServiceStub, 'createPoem').and.returnValue(spyResponse);
 
     const submitButton = await loader.getHarness(
         MatButtonHarness.with({selector: '.poem-edit-submit'}));
@@ -99,8 +108,6 @@ describe('MyPoemsEditDialog', () => {
     const poemTextField = await loader.getHarness(
         MatInputHarness.with({selector: '.poem-text-field'}));
 
-    const testName = 'testName';
-    const testPoem = 'testPoem';
     await poemNameField.setValue(testName);
     await poemTextField.setValue(testPoem);
     await submitButton.click();

--- a/src/app/my-poems/my-poems.component.spec.ts
+++ b/src/app/my-poems/my-poems.component.spec.ts
@@ -4,7 +4,9 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatCardModule} from '@angular/material/card';
 import {MatDialogModule} from '@angular/material/dialog';
 import {MatGridListModule} from '@angular/material/grid-list';
+import {BackendService} from '../backend.service';
 import {MyPoemsListComponent} from '../my-poems-list/my-poems-list.component';
+import {BackendServiceStub} from '../testing/backend-service-stub';
 
 import {MyPoemsComponent} from './my-poems.component';
 
@@ -25,6 +27,9 @@ describe('MyPoemsComponent', () => {
           declarations: [
             MyPoemsComponent,
             MyPoemsListComponent,
+          ],
+          providers: [
+            {provide: BackendService, useValue: new BackendServiceStub()},
           ],
         })
         .compileComponents();

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -68,7 +68,7 @@ export class BackendServiceStub extends BaseBackendService {
     });
   }
 
-  getManualPoems(numPoems = 0): void {
+  async getManualPoems(numPoems = 0): Promise<void> {
     // Sort the poems by modified timestamp or creation timestamp if no modified
     // timestamp exists
     const getSortValue = function(p: Poem) {
@@ -92,6 +92,6 @@ export class BackendServiceStub extends BaseBackendService {
 
     // Send the response to the manual poems subject
     const response: GetPoemsResponse = {type: 'manual', poems: manualPoems};
-    this.manualPoemsSubject.next(of(response));
+    this.manualPoemsSubject.next(response);
   }
 }


### PR DESCRIPTION
Add functionality to the backend service that will query the `/api/get_poems/` route to fetch poems.

Previously, the backend service did not have a function that queried the new `/api/get_poems/` route on the backend server.
Now, the backend service has a `manualPoems$' that components can use to listen for manual poems. A new set of manual poems can be triggered with the `getManualPoems` function.

Added tests to:
- check that the backend service can fetch manually written poems