### PR TITLE
Display manual poems

### DIFF
--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -102,6 +102,11 @@ describe('BackendService', () => {
     };
     req.flush(resp);
 
+    // Creating a poem also triggers a refetch of the manual poems
+    const poemsReq = controller.expectOne(`${
+        backendUrl}/api/get_poems/manual/0/${authServiceStub.getUserEmail()}`);
+    poemsReq.flush(null);
+
     // Assert there are no extra requests
     controller.verify();
   });

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -21,11 +21,7 @@ export abstract class BaseBackendService {
       Observable<CreatePoemResponse>;
 
   // Functions that trigger an update to a poem observable
-<<<<<<< HEAD
   abstract getManualPoems(numPoems: number): Promise<void>|Promise<Poem[]>;
-=======
-  abstract getManualPoems(numPoems: number): void|Poem[];
->>>>>>> add test for displaying manually written poems
 }
 
 @Injectable({providedIn: 'root'})

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -21,7 +21,11 @@ export abstract class BaseBackendService {
       Observable<CreatePoemResponse>;
 
   // Functions that trigger an update to a poem observable
+<<<<<<< HEAD
   abstract getManualPoems(numPoems: number): Promise<void>|Promise<Poem[]>;
+=======
+  abstract getManualPoems(numPoems: number): void|Poem[];
+>>>>>>> add test for displaying manually written poems
 }
 
 @Injectable({providedIn: 'root'})

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -1,7 +1,7 @@
 import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {firstValueFrom, Observable, of, Subject} from 'rxjs';
-import {catchError, map} from 'rxjs/operators';
+import {catchError, map, tap} from 'rxjs/operators';
 
 import {environment} from '../environments/environment';
 import {AuthService} from './auth.service';
@@ -70,7 +70,10 @@ export class BackendService extends BaseBackendService {
     const endpoint = `${this.url}/api/create_poem`;
     return this.http
         .post<CreatePoemResponse>(endpoint, requestBody, this.httpOptions)
-        .pipe(catchError(this.handleError<CreatePoemResponse>('createPoem')));
+        .pipe(
+            catchError(this.handleError<CreatePoemResponse>('createPoem')),
+            tap(_ => this.getManualPoems()),
+        );
   }
 
   async getManualPoems(numPoems = 0): Promise<void> {

--- a/src/app/my-poems-list/my-poems-list.component.css
+++ b/src/app/my-poems-list/my-poems-list.component.css
@@ -1,3 +1,11 @@
 .new-my-poems-card {
     cursor: pointer;
 }
+
+.my-poem-card .my-poem-name {
+    text-align: left;
+}
+
+.my-poem-card .my-poem-text {
+    white-space: pre;
+}

--- a/src/app/my-poems-list/my-poems-list.component.html
+++ b/src/app/my-poems-list/my-poems-list.component.html
@@ -1,3 +1,12 @@
 <h1>My Poems</h1>
 
 <mat-card class="new-my-poems-card" (click)="openEditDialog()">New Poem</mat-card>
+
+<mat-card class="my-poem-card" *ngFor="let poem of myPoems$ | async">
+    <div class="my-poem-name">
+        <h3>{{poem.name}}</h3>
+    </div>
+    <div class="my-poem-text">
+        <label>{{poem.text}}</label>
+    </div>
+</mat-card>

--- a/src/app/my-poems-list/my-poems-list.component.html
+++ b/src/app/my-poems-list/my-poems-list.component.html
@@ -1,12 +1,14 @@
 <h1>My Poems</h1>
 
-<mat-card class="new-my-poems-card" (click)="openEditDialog()">New Poem</mat-card>
+<mat-card class="new-my-poems-card" (click)="openEditDialog()">
+    <mat-card-title>New Poem</mat-card-title>
+</mat-card>
 
 <mat-card class="my-poem-card" *ngFor="let poem of myPoems$ | async">
-    <div class="my-poem-name">
-        <h3>{{poem.name}}</h3>
-    </div>
-    <div class="my-poem-text">
-        <label>{{poem.text}}</label>
-    </div>
+    <mat-card-title>
+        {{poem.name}}
+    </mat-card-title>
+    <mat-card-content class="my-poem-text">
+        {{poem.text}}
+    </mat-card-content>
 </mat-card>

--- a/src/app/my-poems-list/my-poems-list.component.spec.ts
+++ b/src/app/my-poems-list/my-poems-list.component.spec.ts
@@ -42,6 +42,7 @@ describe('MyPoemsListComponent', () => {
     component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
+    backendServiceStub.getManualPoems();
   });
 
   it('should create', () => {
@@ -71,16 +72,14 @@ describe('MyPoemsListComponent', () => {
   it('should display the saved manual poems', async () => {
     let myPoemCards = await loader.getAllHarnesses(
         MatCardHarness.with({selector: '.my-poem-card'}));
-
     let expectedPoems =
         await backendServiceStub.getManualPoems(0, testUser.id, false);
 
-    // Check that there is one card for each manual poem
+    // Check that there is one card for each poem
     expect(myPoemCards.length).toEqual(expectedPoems.length);
 
     // Add a new manual poem and check again
     backendServiceStub.createPoem('new manual poem', 'some test text', false);
-
     myPoemCards = await loader.getAllHarnesses(
         MatCardHarness.with({selector: '.my-poem-card'}));
     expectedPoems =
@@ -90,5 +89,12 @@ describe('MyPoemsListComponent', () => {
     expect(myPoemCards.length).toEqual(expectedPoems.length);
 
     // Check the card contents
+    for (let i = 0; i < myPoemCards.length; i++) {
+      const card = myPoemCards[i];
+      const poem = expectedPoems[i];
+
+      expect(await card.getTitleText()).toContain(poem.name);
+      expect(await card.getText()).toContain(poem.text);
+    }
   });
 });

--- a/src/app/my-poems-list/my-poems-list.component.spec.ts
+++ b/src/app/my-poems-list/my-poems-list.component.spec.ts
@@ -6,6 +6,7 @@ import {MatCardHarness} from '@angular/material/card/testing';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
 import {MatDialogHarness} from '@angular/material/dialog/testing';
 import {BackendService} from '../backend.service';
+import {User} from '../backend_response_types';
 import {MyPoemsEditDialog} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
 import {BackendServiceStub} from '../testing/backend-service-stub';
 
@@ -16,9 +17,11 @@ describe('MyPoemsListComponent', () => {
   let component: MyPoemsListComponent;
   let fixture: ComponentFixture<MyPoemsListComponent>;
   let loader: HarnessLoader;
+  let testUser: User;
 
   beforeEach(async () => {
     backendServiceStub = new BackendServiceStub();
+    testUser = backendServiceStub.user[0];
 
     await TestBed
         .configureTestingModule({
@@ -63,5 +66,29 @@ describe('MyPoemsListComponent', () => {
             MyPoemsEditDialog,
             {data: undefined},
         );
+  });
+
+  it('should display the saved manual poems', async () => {
+    let myPoemCards = await loader.getAllHarnesses(
+        MatCardHarness.with({selector: '.my-poem-card'}));
+
+    let expectedPoems =
+        await backendServiceStub.getManualPoems(0, testUser.id, false);
+
+    // Check that there is one card for each manual poem
+    expect(myPoemCards.length).toEqual(expectedPoems.length);
+
+    // Add a new manual poem and check again
+    backendServiceStub.createPoem('new manual poem', 'some test text', false);
+
+    myPoemCards = await loader.getAllHarnesses(
+        MatCardHarness.with({selector: '.my-poem-card'}));
+    expectedPoems =
+        await backendServiceStub.getManualPoems(0, testUser.id, false);
+
+    // Check that there is one card for each manual poem including the new one
+    expect(myPoemCards.length).toEqual(expectedPoems.length);
+
+    // Check the card contents
   });
 });

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -11,8 +11,7 @@ import {MyPoemsEditDialog} from '../my-poems-edit-dialog/my-poems-edit-dialog.co
   styleUrls: ['./my-poems-list.component.css']
 })
 export class MyPoemsListComponent implements OnInit {
-  readonly myPoems$: Observable<Poem[]> =
-      this.backendService.manualPoemsObservable$;
+  readonly myPoems$: Observable<Poem[]> = this.backendService.manualPoems$;
 
   constructor(
       private backendService: BackendService,

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {AfterContentInit, AfterViewInit, Component, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {Observable} from 'rxjs';
 import {BackendService} from '../backend.service';
@@ -19,10 +19,6 @@ export class MyPoemsListComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.backendService.getManualPoems();
-  }
-
-  test() {
     this.backendService.getManualPoems();
   }
 

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -1,4 +1,4 @@
-import {AfterContentInit, AfterViewInit, Component, OnInit} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {Observable} from 'rxjs';
 import {BackendService} from '../backend.service';

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -1,5 +1,7 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
+import {Observable} from 'rxjs';
+import {BackendService} from '../backend.service';
 import {Poem} from '../backend_response_types';
 import {MyPoemsEditDialog} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
 
@@ -8,8 +10,22 @@ import {MyPoemsEditDialog} from '../my-poems-edit-dialog/my-poems-edit-dialog.co
   templateUrl: './my-poems-list.component.html',
   styleUrls: ['./my-poems-list.component.css']
 })
-export class MyPoemsListComponent {
-  constructor(public editDialog: MatDialog) {}
+export class MyPoemsListComponent implements OnInit {
+  readonly myPoems$: Observable<Poem[]> =
+      this.backendService.manualPoemsObservable$;
+
+  constructor(
+      private backendService: BackendService,
+      public editDialog: MatDialog,
+  ) {}
+
+  ngOnInit(): void {
+    this.backendService.getManualPoems();
+  }
+
+  test() {
+    this.backendService.getManualPoems();
+  }
 
   async openEditDialog(poem?: Poem): Promise<void> {
     this.editDialog.open(

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -12,7 +12,7 @@ export class BackendServiceStub extends BaseBackendService {
     super();
 
     // Initialize fake tables with testing data
-    this.user = [{'id': 1, 'email': 'user@gmail.com'}];
+    this.user = [{'id': 1, 'email': 'test_user@gmail.com'}];
     this.poem = [{
       'id': 1,
       'user_id': this.user[0].id,
@@ -117,10 +117,12 @@ export class BackendServiceStub extends BaseBackendService {
 
     // Retrieve manually written poems, sorted by timestamp, limited to numPoems
     // entries
-    const manualPoems =
+    let manualPoems =
         this.poem.filter(poem => !poem.generated && (poem.user_id == userId))
-            .sort((a, b) => getSortValue(b) - getSortValue(a))
-            .slice(numPoems);
+            .sort((a, b) => getSortValue(b) - getSortValue(a));
+    if (manualPoems.length > numPoems && numPoems > 0) {
+      manualPoems = manualPoems.slice(0, numPoems);
+    }
 
     // Send the response to the manual poems subject
     if (triggerUpdate) {

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -13,7 +13,20 @@ export class BackendServiceStub extends BaseBackendService {
 
     // Initialize fake tables with testing data
     this.user = [{'id': 1, 'email': 'user@gmail.com'}];
-    this.poem = [];
+    this.poem = [{
+      'id': 1,
+      'user_id': this.user[0].id,
+      'creation_timestamp': new Date(),
+      'modified_timestamp': null,
+      'privacy_level': PoemPrivacyLevel.Public,
+      'archived': true,
+      'form': null,
+      'generated': false,
+      'name': 'test poem',
+      'text': 'test\ntext',
+      'num_likes': 0,
+      'num_dislikes': 0,
+    }];
   }
 
   createUser(email: string): Observable<CreateUserResponse> {
@@ -62,16 +75,33 @@ export class BackendServiceStub extends BaseBackendService {
 
     this.poem.push(newPoem);
 
+    this.getManualPoems();
+
     return of({
       'created': true,
       'poem': newPoem,
     });
   }
 
-  async getManualPoems(numPoems = 0): Promise<void> {
+  /**
+   * Test version of the backend service's getManualPoems.
+   * Includes a few additional parameters and a return value to help testing
+   *
+   * @param {number} numPoems - The maximum number of poems to retrieve
+   * @param {number} userId - If supplied, which user to get poems for. Defaults
+   *     to the test user
+   * @param {triggerUpdate} - If true, will send the result through the
+   *     service's observables which will trigger UI updates. Set to false to
+   * just get the values that exists to compare to the displayed values
+   *
+   * @returns {Peom[]} - The list of manually written poems that match the
+   *     userId, up to numPeoms are returned
+   */
+  async getManualPoems(numPoems = 0, userId?: number, triggerUpdate = true):
+      Promise<Poem[]> {
     // Sort the poems by modified timestamp or creation timestamp if no modified
     // timestamp exists
-    const getSortValue = function(p: Poem) {
+    const getSortValue = (p: Poem) => {
       if (p.modified_timestamp) {
         return p.modified_timestamp.getTime();
       } else if (p.creation_timestamp) {
@@ -81,17 +111,23 @@ export class BackendServiceStub extends BaseBackendService {
       }
     };
 
+    if (userId == undefined) {
+      userId = this.user[0].id;
+    }
+
     // Retrieve manually written poems, sorted by timestamp, limited to numPoems
     // entries
     const manualPoems =
-        this.poem
-            .filter(
-                poem => !poem.generated && (poem.user_id == this.user[0].id))
+        this.poem.filter(poem => !poem.generated && (poem.user_id == userId))
             .sort((a, b) => getSortValue(b) - getSortValue(a))
             .slice(numPoems);
 
     // Send the response to the manual poems subject
-    const response: GetPoemsResponse = {type: 'manual', poems: manualPoems};
-    this.manualPoemsSubject.next(response);
+    if (triggerUpdate) {
+      const response: GetPoemsResponse = {type: 'manual', poems: manualPoems};
+      this.manualPoemsSubject.next(response);
+    }
+
+    return manualPoems;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,10 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2020",
-    "lib": ["es2020", "dom"]
+    "lib": [
+      "es2020",
+      "dom"
+    ]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
Create ui elements to display user's manually written poems.

Previously, there was no part of the UI that displayed the user's manually written poems.
Now, the My Poems page will contain a card for each of the user's poems with the poems title and text:
![image](https://user-images.githubusercontent.com/15317173/118288105-b2effb80-b499-11eb-8ef3-1cc975e3559d.png)

Added tests to:
- check that the My Poems page has cards for each written poem and updates when a new poem is added

Updated tests to:
- check that the backend service creating poems also triggers a get poems refresh

