### PR TITLE
Refactor get poems rxjs

### DIFF
--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -102,26 +102,18 @@ describe('BackendService', () => {
     };
     req.flush(resp);
 
-    // Creating a poem also triggers a refetch of the manual poems
-    const poemsReq = controller.expectOne(`${
-        backendUrl}/api/get_poems/manual/0/${authServiceStub.getUserEmail()}`);
-    poemsReq.flush(null);
-
     // Assert there are no extra requests
     controller.verify();
   });
 
   it('should retrieve manually written poems', () => {
-    const num_poems_to_get = 5;
-
-    // Call the backend create_poem endpoint
-    service.manualPoems$.subscribe(
-        poems => expect(poems.length).toBeLessThanOrEqual(num_poems_to_get));
-    service.getManualPoems(num_poems_to_get);
+    // Call the backend get_poems endpoint
+    const manualPoems$ = service.getManualPoems();
+    manualPoems$.subscribe(poems => expect(poems.length).toBeGreaterThan(0));
 
     // Make sure we called the correct endpoint
-    const req = controller.expectOne(`${backendUrl}/api/get_poems/manual/${
-        num_poems_to_get}/${authServiceStub.getUserEmail()}`);
+    const req = controller.expectOne(`${backendUrl}/api/get_poems/manual/0/${
+        authServiceStub.getUserEmail()}`);
     expect(req.request.method).toEqual('GET');
 
     // Respond with some test information

--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -58,10 +58,20 @@ describe('BackendService', () => {
     controller.verify();
   });
 
-  it('should create poems', () => {
+  it('should create manual poems', () => {
     const expectedPoemName = 'testName';
     const expectedPoemText = 'test text\nsecond line';
     const generated = false;
+
+    // Subscribe to the manual poems refresh
+    const manualPoems$ = service.getManualPoems();
+    manualPoems$.subscribe();
+
+    // Expect the initial manual poem fetch
+    let poemsReq = controller.expectOne(`${backendUrl}/api/get_poems/manual/0/${
+        authServiceStub.getUserEmail()}`);
+    poemsReq.flush({type: 'manual', poems: []});
+
 
     // Call the backend create_poem endpoint
     service.createPoem(expectedPoemName, expectedPoemText, generated)
@@ -101,6 +111,11 @@ describe('BackendService', () => {
       },
     };
     req.flush(resp);
+
+    // Creting a poem also refreshes the list of poems
+    poemsReq = controller.expectOne(`${backendUrl}/api/get_poems/manual/0/${
+        authServiceStub.getUserEmail()}`);
+    poemsReq.flush({type: 'manual', poems: []});
 
     // Assert there are no extra requests
     controller.verify();

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -10,7 +10,7 @@ import {CreatePoemResponse, CreateUserResponse, GetPoemsResponse, Poem} from './
 @Injectable({providedIn: 'root'})
 export abstract class BaseBackendService {
   // Subject emits whenever the list of poems needs to be refreshed
-  protected refreshManualPoemsSubject = new Subject<void>();
+  refreshManualPoemsSubject = new Subject<void>();
 
   // Observables for the various types of poems
   readonly manualPoems$ = this.refreshManualPoemsSubject.pipe(

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -1,7 +1,7 @@
 import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {firstValueFrom, Observable, of, Subject} from 'rxjs';
-import {catchError, map, tap} from 'rxjs/operators';
+import {catchError, map, mergeMap, startWith, tap} from 'rxjs/operators';
 
 import {environment} from '../environments/environment';
 import {AuthService} from './auth.service';
@@ -9,19 +9,35 @@ import {CreatePoemResponse, CreateUserResponse, GetPoemsResponse, Poem} from './
 
 @Injectable({providedIn: 'root'})
 export abstract class BaseBackendService {
-  // Observables and subjects for the various types of poems
-  protected manualPoemsSubject = new Subject<GetPoemsResponse>();
-  readonly manualPoems$ =
-      this.manualPoemsSubject.pipe(map(response => response.poems));
+  // Subject emits whenever the list of poems needs to be refreshed
+  protected refreshManualPoemsSubject = new Subject<void>();
 
-  // Functions to create new information. The backend will create new rows in
-  // the database
+  // Observables for the various types of poems
+  readonly manualPoems$ = this.refreshManualPoemsSubject.pipe(
+      startWith(void 0),
+      mergeMap(() => this._getPoemsRequest('manual', 0)),
+      map(serverResponse => serverResponse.poems),
+  );
+
+  // Functions to create new information. The backend will create new rows
+  // in the database
   abstract createUser(email: string): Observable<CreateUserResponse>;
   abstract createPoem(poemName: string, poemText: string, generated: boolean):
       Observable<CreatePoemResponse>;
 
-  // Functions that trigger an update to a poem observable
-  abstract getManualPoems(numPoems: number): Promise<void>|Promise<Poem[]>;
+  // Functions that trigger an update to a poem observable or return an
+  // observable that the front end can subscribe to
+  refreshManualPoems(): void {
+    this.refreshManualPoemsSubject.next();
+  }
+
+  getManualPoems(): Observable<Poem[]> {
+    return this.manualPoems$;
+  }
+
+  // Returns the http get Observable for fetching poems
+  protected abstract _getPoemsRequest(poemType: string, numPoems: number):
+      Observable<GetPoemsResponse>;
 }
 
 @Injectable({providedIn: 'root'})
@@ -72,14 +88,8 @@ export class BackendService extends BaseBackendService {
         .post<CreatePoemResponse>(endpoint, requestBody, this.httpOptions)
         .pipe(
             catchError(this.handleError<CreatePoemResponse>('createPoem')),
-            tap(_ => this.getManualPoems()),
+            tap(_ => this.refreshManualPoems()),
         );
-  }
-
-  async getManualPoems(numPoems = 0): Promise<void> {
-    const manualPoems =
-        await firstValueFrom(this._getPoemsRequest('manual', numPoems));
-    this.manualPoemsSubject.next(manualPoems);
   }
 
   protected _getPoemsRequest(poemType: string, numPoems: number):

--- a/src/app/my-poems-list/my-poems-list.component.spec.ts
+++ b/src/app/my-poems-list/my-poems-list.component.spec.ts
@@ -5,6 +5,7 @@ import {MatCardModule} from '@angular/material/card';
 import {MatCardHarness} from '@angular/material/card/testing';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
 import {MatDialogHarness} from '@angular/material/dialog/testing';
+import {firstValueFrom} from 'rxjs';
 import {BackendService} from '../backend.service';
 import {User} from '../backend_response_types';
 import {MyPoemsEditDialog} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
@@ -72,26 +73,26 @@ describe('MyPoemsListComponent', () => {
   it('should display the saved manual poems', async () => {
     let myPoemCards = await loader.getAllHarnesses(
         MatCardHarness.with({selector: '.my-poem-card'}));
-    let expectedPoems =
-        await backendServiceStub.getManualPoems(0, testUser.id, false);
+    let expectedPoemsResponse =
+        await firstValueFrom(backendServiceStub._getManualPoemsRequest());
 
     // Check that there is one card for each poem
-    expect(myPoemCards.length).toEqual(expectedPoems.length);
+    expect(myPoemCards.length).toEqual(expectedPoemsResponse.poems.length);
 
     // Add a new manual poem and check again
     backendServiceStub.createPoem('new manual poem', 'some test text', false);
     myPoemCards = await loader.getAllHarnesses(
         MatCardHarness.with({selector: '.my-poem-card'}));
-    expectedPoems =
-        await backendServiceStub.getManualPoems(0, testUser.id, false);
+    expectedPoemsResponse =
+        await firstValueFrom(backendServiceStub._getManualPoemsRequest());
 
     // Check that there is one card for each manual poem including the new one
-    expect(myPoemCards.length).toEqual(expectedPoems.length);
+    expect(myPoemCards.length).toEqual(expectedPoemsResponse.poems.length);
 
     // Check the card contents
     for (let i = 0; i < myPoemCards.length; i++) {
       const card = myPoemCards[i];
-      const poem = expectedPoems[i];
+      const poem = expectedPoemsResponse.poems[i];
 
       expect(await card.getTitleText()).toContain(poem.name);
       expect(await card.getText()).toContain(poem.text);

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -75,7 +75,7 @@ export class BackendServiceStub extends BaseBackendService {
 
     this.poem.push(newPoem);
 
-    this.getManualPoems();
+    this.refreshManualPoems();
 
     return of({
       'created': true,
@@ -84,21 +84,29 @@ export class BackendServiceStub extends BaseBackendService {
   }
 
   /**
-   * Test version of the backend service's getManualPoems.
+   * Test version of the backend service's _getPoemsResponse.
    * Includes a few additional parameters and a return value to help testing
    *
+   * @param {string} poemType - one of 'best', 'new', 'manual', 'liked',
+   *     'generated'. Currently only manual is implemented
    * @param {number} numPoems - The maximum number of poems to retrieve
    * @param {number} userId - If supplied, which user to get poems for. Defaults
    *     to the test user
-   * @param {triggerUpdate} - If true, will send the result through the
-   *     service's observables which will trigger UI updates. Set to false to
-   * just get the values that exists to compare to the displayed values
    *
-   * @returns {Peom[]} - The list of manually written poems that match the
-   *     userId, up to numPeoms are returned
+   * @returns {Observable<GetPoemsResponse>} - The list of manually written
+   *     poems that match the userId, up to numPeoms are returned
    */
-  async getManualPoems(numPoems = 0, userId?: number, triggerUpdate = true):
-      Promise<Poem[]> {
+  _getPoemsRequest(poemType: string, numPeoms: number, userId?: number):
+      Observable<GetPoemsResponse> {
+    if (poemType == 'manual') {
+      return this._getManualPoemsRequest(0, userId);
+    } else {
+      throw new Error('Other poem types not yet implemented');
+    }
+  }
+
+  _getManualPoemsRequest(numPoems = 0, userId?: number):
+      Observable<GetPoemsResponse> {
     // Sort the poems by modified timestamp or creation timestamp if no modified
     // timestamp exists
     const getSortValue = (p: Poem) => {
@@ -124,12 +132,6 @@ export class BackendServiceStub extends BaseBackendService {
       manualPoems = manualPoems.slice(0, numPoems);
     }
 
-    // Send the response to the manual poems subject
-    if (triggerUpdate) {
-      const response: GetPoemsResponse = {type: 'manual', poems: manualPoems};
-      this.manualPoemsSubject.next(response);
-    }
-
-    return manualPoems;
+    return of({type: 'manual', poems: manualPoems});
   }
 }


### PR DESCRIPTION
Refactor the rxjs pipelines for getting and refreshing the list of manual poems.

Previously, the UI that displayed the list of manual poems relied on awaiting an http get request from the backend server.
This has been cleaned up to no longer await the server request.

No functional changes should be visible in the UI.
