### PR TITLE
Refactor create poems rxjs

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import {Location} from '@angular/common';
+import {CommonModule, Location} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {MatDividerModule} from '@angular/material/divider';
@@ -23,6 +23,7 @@ describe('AppComponent', () => {
     TestBed
         .configureTestingModule({
           imports: [
+            CommonModule,
             MatButtonModule,
             MatDividerModule,
             MatGridListModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import {ExampleComponent} from './example/example.component';
 import {HomeComponent} from './home/home.component';
 import {LoginButtonComponent} from './login-button/login-button.component';
 import {MaterialModule} from './material/material.module';
+import {MessagePopup} from './message-popup/message-popup.component';
 import {MyPoemsEditDialog} from './my-poems-edit-dialog/my-poems-edit-dialog.component';
 import {MyPoemsListComponent} from './my-poems-list/my-poems-list.component';
 import {MyPoemsComponent} from './my-poems/my-poems.component';
@@ -26,6 +27,7 @@ import {NavigationComponent} from './navigation/navigation.component';
     MyPoemsComponent,
     MyPoemsEditDialog,
     MyPoemsListComponent,
+    MessagePopup,
   ],
   imports: [
     BrowserModule,

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -23,7 +23,7 @@ export abstract class BaseBackendService {
   // in the database
   abstract createUser(email: string): Observable<CreateUserResponse>;
   abstract createPoem(poemName: string, poemText: string, generated: boolean):
-      Observable<CreatePoemResponse>;
+      Observable<CreatePoemResponse|undefined>;
 
   // Functions that trigger an update to a poem observable or return an
   // observable that the front end can subscribe to
@@ -68,7 +68,7 @@ export class BackendService extends BaseBackendService {
   }
 
   createPoem(poemName: string, poemText: string, generated: boolean):
-      Observable<CreatePoemResponse> {
+      Observable<CreatePoemResponse|undefined> {
     // There must be a user logged in to associate with the new poem
     const userEmail: string|undefined = this.auth.getUserEmail();
     if (!userEmail)

--- a/src/app/message-popup/message-popup.component.html
+++ b/src/app/message-popup/message-popup.component.html
@@ -1,0 +1,7 @@
+<div class="message-text" *ngIf="data$ | async as data; else elseBlock">
+    {{data}}
+    <button mat-stroked-button color="primary" (click)="dismiss()">Dismiss</button>
+</div>
+<ng-template #elseBlock>
+    <div class="message-text">Loading...</div>
+</ng-template>

--- a/src/app/message-popup/message-popup.component.spec.ts
+++ b/src/app/message-popup/message-popup.component.spec.ts
@@ -1,0 +1,60 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {CommonModule} from '@angular/common';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_SNACK_BAR_DATA, MatSnackBarModule} from '@angular/material/snack-bar';
+import {Subject} from 'rxjs';
+
+import {MessagePopup} from './message-popup.component';
+
+describe('MessagePopupComponent', () => {
+  let component: MessagePopup;
+  let fixture: ComponentFixture<MessagePopup>;
+  let loader: HarnessLoader;
+  let popupMessageSubject: Subject<string>;
+
+  beforeEach(async () => {
+    popupMessageSubject = new Subject<string>();
+
+    await TestBed
+        .configureTestingModule({
+          declarations: [MessagePopup],
+          imports: [
+            CommonModule,
+            MatSnackBarModule,
+          ],
+          providers: [{
+            provide: MAT_SNACK_BAR_DATA,
+            useValue: popupMessageSubject.asObservable()
+          }]
+        })
+        .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MessagePopup);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display a message from the data observable', () => {
+    // Before the message observable resolves, it should display a loading
+    // message
+    let messageTextElement =
+        fixture.nativeElement.querySelector('.message-text');
+    expect(messageTextElement.textContent).toContain('Loading');
+
+    // After the  message observable resolves, the text should change
+    const testText = 'test';
+    popupMessageSubject.next(testText);
+    fixture.detectChanges();
+
+    messageTextElement = fixture.nativeElement.querySelector('.message-text');
+    expect(messageTextElement.textContent).toContain(testText);
+  });
+});

--- a/src/app/message-popup/message-popup.component.ts
+++ b/src/app/message-popup/message-popup.component.ts
@@ -1,0 +1,19 @@
+import {Component, Inject} from '@angular/core';
+import {MAT_SNACK_BAR_DATA, MatSnackBar} from '@angular/material/snack-bar';
+import {Observable} from 'rxjs';
+
+@Component({
+  selector: 'app-message-popup',
+  templateUrl: './message-popup.component.html',
+  styleUrls: ['./message-popup.component.css']
+})
+export class MessagePopup {
+  constructor(
+      @Inject(MAT_SNACK_BAR_DATA) public data$: Observable<string>,
+      public snackBar: MatSnackBar,
+  ) {}
+
+  dismiss(): void {
+    this.snackBar.dismiss();
+  }
+}

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.spec.ts
@@ -1,5 +1,6 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
@@ -8,10 +9,12 @@ import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatInputHarness} from '@angular/material/input/testing';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {of} from 'rxjs';
+import {firstValueFrom} from 'rxjs';
 
 import {BackendService} from '../backend.service';
+import {MessagePopup} from '../message-popup/message-popup.component';
 import {BackendServiceStub} from '../testing/backend-service-stub';
 
 import {MyPoemsEditDialog} from './my-poems-edit-dialog.component';
@@ -27,13 +30,18 @@ describe('MyPoemsEditDialog', () => {
 
     await TestBed
         .configureTestingModule({
-          declarations: [MyPoemsEditDialog],
+          declarations: [
+            MessagePopup,
+            MyPoemsEditDialog,
+          ],
           imports: [
             BrowserAnimationsModule,
+            CommonModule,
             FormsModule,
             MatButtonModule,
             MatFormFieldModule,
             MatInputModule,
+            MatSnackBarModule,
           ],
           providers: [
             {provide: BackendService, useValue: backendServiceStub},
@@ -96,6 +104,10 @@ describe('MyPoemsEditDialog', () => {
     const testName = 'testName';
     const testPoem = 'testPoem';
 
+    // Set up spy on dialog box
+    const snackBar = TestBed.inject(MatSnackBar);
+    const snackBarSpy = spyOn(snackBar, 'openFromComponent');
+
     // Set up backend service spy
     const spyResponse =
         backendServiceStub.createPoem(testName, testPoem, false);
@@ -114,5 +126,14 @@ describe('MyPoemsEditDialog', () => {
 
     expect(backendServiceStub.createPoem)
         .toHaveBeenCalledWith(testName, testPoem, false);
+
+    const snackBarSpyArgs = snackBarSpy.calls.mostRecent().args;
+    expect(snackBarSpy).toHaveBeenCalled();
+    expect(snackBarSpyArgs[0]).toBe(MessagePopup);
+
+    if (!snackBarSpyArgs[1])
+      throw new Error('Failed to find second argument for popup message');
+    expect(await firstValueFrom(snackBarSpyArgs[1].data))
+        .toContain('Poem Created!');
   });
 });

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
@@ -18,9 +18,9 @@ export class MyPoemsEditDialog {
 
   constructor(
       private backendService: BackendService,
-      public dialogRef: MatDialogRef<MyPoemsEditDialog>,
+      private dialogRef: MatDialogRef<MyPoemsEditDialog>,
       @Inject(MAT_DIALOG_DATA) public data: Poem,
-      public snackBar: MatSnackBar,
+      private snackBar: MatSnackBar,
   ) {}
 
   canSubmit(): boolean {

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
@@ -35,7 +35,9 @@ export class MyPoemsEditDialog {
           {
             data: this.backendService
                       .createPoem(this.poemName, this.poemText, false)
-                      .pipe(map(() => 'Poem Created!'))
+                      .pipe(
+                          map(response => response ? 'Poem Created!' :
+                                                     'Failed to create poem.'))
           },
       );
     }

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
@@ -1,9 +1,11 @@
 import {Component, Inject} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
-import {firstValueFrom} from 'rxjs';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {map} from 'rxjs/operators';
 import {BackendService} from '../backend.service';
 
 import {Poem} from '../backend_response_types';
+import {MessagePopup} from '../message-popup/message-popup.component';
 
 @Component({
   selector: 'app-my-poems-edit-dialog',
@@ -18,6 +20,7 @@ export class MyPoemsEditDialog {
       private backendService: BackendService,
       public dialogRef: MatDialogRef<MyPoemsEditDialog>,
       @Inject(MAT_DIALOG_DATA) public data: Poem,
+      public snackBar: MatSnackBar,
   ) {}
 
   canSubmit(): boolean {
@@ -27,13 +30,14 @@ export class MyPoemsEditDialog {
 
   async submit(): Promise<void> {
     if (this.canSubmit()) {
-      const response = await firstValueFrom(
-          this.backendService.createPoem(this.poemName, this.poemText, false));
-
-      if (!response) {
-        throw new Error(
-            'Failed to get a response from the backend for creating a poem');
-      }
+      this.snackBar.openFromComponent(
+          MessagePopup,
+          {
+            data: this.backendService
+                      .createPoem(this.poemName, this.poemText, false)
+                      .pipe(map(() => 'Poem Created!'))
+          },
+      );
     }
     this.dialogRef.close();
   }

--- a/src/app/my-poems-list/my-poems-list.component.spec.ts
+++ b/src/app/my-poems-list/my-poems-list.component.spec.ts
@@ -1,10 +1,10 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatCardModule} from '@angular/material/card';
 import {MatCardHarness} from '@angular/material/card/testing';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
-import {MatDialogHarness} from '@angular/material/dialog/testing';
 import {firstValueFrom} from 'rxjs';
 import {BackendService} from '../backend.service';
 import {User} from '../backend_response_types';
@@ -27,6 +27,7 @@ describe('MyPoemsListComponent', () => {
     await TestBed
         .configureTestingModule({
           imports: [
+            CommonModule,
             MatCardModule,
             MatDialogModule,
           ],

--- a/src/app/my-poems-list/my-poems-list.component.ts
+++ b/src/app/my-poems-list/my-poems-list.component.ts
@@ -13,6 +13,8 @@ import {MyPoemsEditDialog} from '../my-poems-edit-dialog/my-poems-edit-dialog.co
 export class MyPoemsListComponent implements OnInit {
   readonly myPoems$: Observable<Poem[]> = this.backendService.manualPoems$;
 
+  newPoemMessage$?: Observable<string>;
+
   constructor(
       private backendService: BackendService,
       public editDialog: MatDialog,

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -53,7 +53,7 @@ export class BackendServiceStub extends BaseBackendService {
   }
 
   createPoem(poemName: string, poemText: string, generated: boolean):
-      Observable<CreatePoemResponse> {
+      Observable<CreatePoemResponse|undefined> {
     if (!this.user.length) {
       throw new Error('No user to create poem for');
     }


### PR DESCRIPTION
Create a snackbar message to the user notifying them when a poem has been created.

Previously, there was no indication to the user when there new poems had been saved except the entire list of poems refreshing.
Now, a snackbar message will notify them:
![image](https://user-images.githubusercontent.com/15317173/118668288-57d04880-b7ba-11eb-9e09-80b911a60fb2.png)

Updated tests:
-to check that creating a poem opens a snackbar message

Added tests:
-the snackbar component shows a loading message while the create is in progress
-the snackbar component shows a message when the create is finished
-the snackbar shows an error message when creating a poem encounters an error
