### PR TITLE
Refactor create user rxjs

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,6 +4,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatDividerModule} from '@angular/material/divider';
 import {MatGridListModule} from '@angular/material/grid-list';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {Router} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 
@@ -28,6 +29,7 @@ describe('AppComponent', () => {
             MatDividerModule,
             MatGridListModule,
             MatProgressSpinnerModule,
+            MatSnackBarModule,
             RouterTestingModule.withRoutes(routes),
           ],
           declarations: [

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -21,7 +21,7 @@ export abstract class BaseBackendService {
 
   // Functions to create new information. The backend will create new rows
   // in the database
-  abstract createUser(email: string): Observable<CreateUserResponse>;
+  abstract createUser(email: string): Observable<CreateUserResponse|undefined>;
   abstract createPoem(poemName: string, poemText: string, generated: boolean):
       Observable<CreatePoemResponse|undefined>;
 
@@ -61,7 +61,7 @@ export class BackendService extends BaseBackendService {
     };
   }
 
-  createUser(email: string): Observable<CreateUserResponse> {
+  createUser(email: string): Observable<CreateUserResponse|undefined> {
     const endpoint = `${this.url}/api/create_user/${email}`;
     return this.http.get<CreateUserResponse>(endpoint).pipe(
         catchError(this.handleError<CreateUserResponse>('createUser')));

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -29,7 +29,7 @@ export class BackendServiceStub extends BaseBackendService {
     }];
   }
 
-  createUser(email: string): Observable<CreateUserResponse> {
+  createUser(email: string): Observable<CreateUserResponse|undefined> {
     let created = false;
     let userRow: User|undefined =
         this.user.find(u => u.email.toLowerCase() === email.toLowerCase());


### PR DESCRIPTION
Create a snackbar message that notifies the user when they have signing in.

Previously, the loading spinner would disappear when the user finished signing in, but no message would be displayed.
Now, a snackbar message indicated to the user that the server has successfully logged them in/created a user for them:
![image](https://user-images.githubusercontent.com/15317173/118676303-e778f580-b7c0-11eb-8b4a-38d843912e26.png)


Updated tests to:
- check that the login button opens a snackbar message

Added test to:
- check that the snackbar gives an appropriate message to returning users.
- check that the snackbar shows an error message if the login fails.