### PR TITLE
Respect poem semantic whitespace

### DIFF
--- a/src/app/backend.service.spec.ts
+++ b/src/app/backend.service.spec.ts
@@ -60,7 +60,7 @@ describe('BackendService', () => {
 
   it('should create manual poems', () => {
     const expectedPoemName = 'testName';
-    const expectedPoemText = 'test text\nsecond line';
+    const expectedPoemText = '   test text   \n  second   line  ';
     const generated = false;
 
     // Subscribe to the manual poems refresh

--- a/src/app/backend.service.ts
+++ b/src/app/backend.service.ts
@@ -78,7 +78,7 @@ export class BackendService extends BaseBackendService {
     const requestBody = {
       userEmail: userEmail,
       poemName: poemName.trim(),
-      poemText: poemText.trim(),
+      poemText: poemText,
       generated: generated,
     };
 

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.css
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.css
@@ -9,3 +9,7 @@
 .poem-edit-form button {
     margin: 0px 5px;
 }
+
+.poem-edit-form .poem-text-field {
+    font-family: monospace;
+}

--- a/src/app/my-poems-list/my-poems-list.component.css
+++ b/src/app/my-poems-list/my-poems-list.component.css
@@ -8,4 +8,6 @@
 
 .my-poem-card .my-poem-text {
     white-space: pre;
+    font-family: monospace;
+    text-align: left;
 }

--- a/src/app/my-poems-list/my-poems-list.component.html
+++ b/src/app/my-poems-list/my-poems-list.component.html
@@ -5,10 +5,6 @@
 </mat-card>
 
 <mat-card class="my-poem-card" *ngFor="let poem of myPoems$ | async">
-    <mat-card-title>
-        {{poem.name}}
-    </mat-card-title>
-    <mat-card-content class="my-poem-text">
-        {{poem.text}}
-    </mat-card-content>
+    <mat-card-title>{{poem.name}}</mat-card-title>
+    <mat-card-content class="my-poem-text">{{poem.text}}</mat-card-content>
 </mat-card>


### PR DESCRIPTION
Update poem text box styling to respect a poem's whitespace and display in a monospace font.

Previously, the poem text box center aligned poem text:
![image](https://user-images.githubusercontent.com/15317173/118702547-af7eac00-b7da-11eb-8f9c-6d6d07d3c601.png)

Now, the poem text will be left aligned and display in a monospace font:
![image](https://user-images.githubusercontent.com/15317173/118702602-c1604f00-b7da-11eb-9289-154f03246153.png)

Updated tests to:
- check that creating a poem respects poem text's whitespace
