### PR TITLE
Edit poem backend service

### DIFF
--- a/src/app/backend_response_types.ts
+++ b/src/app/backend_response_types.ts
@@ -55,3 +55,9 @@ export interface GetPoemsResponse {
   type: string;
   poems: Poem[];
 }
+
+// Models the response for the /api/edit_poem/<int:poemId> endpoint
+export interface EditPoemResponse {
+  edited: boolean;
+  poem: Poem;
+}


### PR DESCRIPTION
Create an interface in the backend service to allow editing poems.

Previously, the backend service did not have a way to call the `edit_poem` endpoint.
Now, the `editPoem(editedPoem: Poem)` function will call the backend's `/api/edit_poem/<int: poem_id>` route to allow editing poems.

Added tests to:
- check that the backend service can edit poems