### PR TITLE
Edit manual poems

### DIFF
--- a/api.py
+++ b/api.py
@@ -4,6 +4,7 @@ import flask
 import logging
 import json
 from datetime import datetime
+from sqlalchemy.sql import func
 
 import models
 from models import db
@@ -116,9 +117,10 @@ def get_poems(poem_type, num_poems, user_email):
     elif poem_type == 'manual':
         query = models.Poem.query.filter_by(
             user_id=user.id, generated=False).order_by(
-                models.Poem.modified_timestamp.desc(),
-                models.Poem.creation_timestamp.desc(),
-            )
+                func.ifnull(
+                    models.Poem.modified_timestamp,
+                    models.Poem.creation_timestamp,
+                ).desc())
         if num_poems > 0:
             query = query.limit(num_poems)
         poems = query.all()

--- a/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
+++ b/src/app/my-poems-edit-dialog/my-poems-edit-dialog.component.ts
@@ -13,6 +13,7 @@ import {MessagePopup} from '../message-popup/message-popup.component';
   styleUrls: ['./my-poems-edit-dialog.component.css']
 })
 export class MyPoemsEditDialog {
+  existingPoem: Poem;
   poemName = '';
   poemText = '';
 
@@ -21,25 +22,45 @@ export class MyPoemsEditDialog {
       private dialogRef: MatDialogRef<MyPoemsEditDialog>,
       @Inject(MAT_DIALOG_DATA) public data: Poem,
       private snackBar: MatSnackBar,
-  ) {}
+  ) {
+    if (data) {
+      this.existingPoem = data;
+      this.poemName = data.name;
+      this.poemText = data.text;
+    }
+  }
 
   canSubmit(): boolean {
-    return (this.poemName.trim().length > 0) &&
-        (this.poemText.trim().length > 0);
+    return (this.poemName.trim().length > 0) && (this.poemText.length > 0);
   }
 
   async submit(): Promise<void> {
     if (this.canSubmit()) {
-      this.snackBar.openFromComponent(
-          MessagePopup,
-          {
-            data: this.backendService
-                      .createPoem(this.poemName, this.poemText, false)
-                      .pipe(
-                          map(response => response ? 'Poem Created!' :
-                                                     'Failed to create poem.'))
-          },
-      );
+      if (this.existingPoem) {
+        this.existingPoem.name = this.poemName;
+        this.existingPoem.text = this.poemText;
+
+        this.snackBar.openFromComponent(
+            MessagePopup,
+            {
+              data: this.backendService.editPoem(this.existingPoem)
+                        .pipe(
+                            map(response => response ? 'Poem edit complete.' :
+                                                       'Failed to edit poem.'))
+            },
+        );
+      } else {
+        this.snackBar.openFromComponent(
+            MessagePopup,
+            {
+              data: this.backendService
+                        .createPoem(this.poemName, this.poemText, false)
+                        .pipe(map(
+                            response => response ? 'Poem Created!' :
+                                                   'Failed to create poem.'))
+            },
+        );
+      }
     }
     this.dialogRef.close();
   }

--- a/src/app/my-poems-list/my-poems-list.component.html
+++ b/src/app/my-poems-list/my-poems-list.component.html
@@ -8,6 +8,6 @@
     <mat-card-title>{{poem.name}}</mat-card-title>
     <mat-card-content class="my-poem-text">{{poem.text}}</mat-card-content>
     <mat-card-actions>
-        <button mat-stroked-button (click)="openEditDialog(poem)">Edit</button>
+        <button class="edit-poem" mat-stroked-button (click)="openEditDialog(poem)">Edit</button>
     </mat-card-actions>
 </mat-card>

--- a/src/app/my-poems-list/my-poems-list.component.html
+++ b/src/app/my-poems-list/my-poems-list.component.html
@@ -7,4 +7,7 @@
 <mat-card class="my-poem-card" *ngFor="let poem of myPoems$ | async">
     <mat-card-title>{{poem.name}}</mat-card-title>
     <mat-card-content class="my-poem-text">{{poem.text}}</mat-card-content>
+    <mat-card-actions>
+        <button mat-stroked-button (click)="openEditDialog(poem)">Edit</button>
+    </mat-card-actions>
 </mat-card>

--- a/src/app/my-poems-list/my-poems-list.component.spec.ts
+++ b/src/app/my-poems-list/my-poems-list.component.spec.ts
@@ -2,12 +2,13 @@ import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatButtonHarness} from '@angular/material/button/testing';
 import {MatCardModule} from '@angular/material/card';
 import {MatCardHarness} from '@angular/material/card/testing';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
 import {firstValueFrom} from 'rxjs';
 import {BackendService} from '../backend.service';
-import {User} from '../backend_response_types';
+import {Poem, User} from '../backend_response_types';
 import {MyPoemsEditDialog} from '../my-poems-edit-dialog/my-poems-edit-dialog.component';
 import {BackendServiceStub} from '../testing/backend-service-stub';
 
@@ -18,11 +19,10 @@ describe('MyPoemsListComponent', () => {
   let component: MyPoemsListComponent;
   let fixture: ComponentFixture<MyPoemsListComponent>;
   let loader: HarnessLoader;
-  let testUser: User;
+  let dialog: MatDialog;
 
   beforeEach(async () => {
     backendServiceStub = new BackendServiceStub();
-    testUser = backendServiceStub.user[0];
 
     await TestBed
         .configureTestingModule({
@@ -42,6 +42,7 @@ describe('MyPoemsListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MyPoemsListComponent);
     component = fixture.componentInstance;
+    dialog = TestBed.inject(MatDialog);
     loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
     backendServiceStub.getManualPoems();
@@ -53,7 +54,6 @@ describe('MyPoemsListComponent', () => {
 
   it('should open a new poem dialog', () => {
     // Spy on the dialog's open call
-    const dialog = TestBed.inject(MatDialog);
     spyOn(dialog, 'open');
 
     // Click the card to attempt to add a new poem
@@ -98,5 +98,30 @@ describe('MyPoemsListComponent', () => {
       expect(await card.getTitleText()).toContain(poem.name);
       expect(await card.getText()).toContain(poem.text);
     }
+  });
+
+  it('should open the edit dialog', async () => {
+    const manualPoemsResponse =
+        await firstValueFrom(backendServiceStub._getManualPoemsRequest());
+    const testPoem = manualPoemsResponse.poems[0];
+
+    // Spy on the dialog's open call
+    const dialogOpenSpy = spyOn(dialog, 'open');
+
+    const editPoemButton = await loader.getHarness(
+        MatButtonHarness.with({selector: '.edit-poem'}));
+    await editPoemButton.click();
+
+    // Check that the dialog open was called
+    expect(dialog.open).toHaveBeenCalled();
+    const dialogOpenSpyArgs = dialogOpenSpy.calls.mostRecent().args;
+    expect(dialogOpenSpyArgs[0]).toBe(MyPoemsEditDialog);
+
+    if (!dialogOpenSpyArgs[1]) {
+      throw new Error('Failed to find second argument for dialog open');
+    }
+    const dialogPoem = dialogOpenSpyArgs[1].data as Poem;
+    expect(dialogPoem.name).toContain(testPoem.name);
+    expect(dialogPoem.text).toContain(testPoem.text);
   });
 });

--- a/src/app/testing/backend-service-stub.ts
+++ b/src/app/testing/backend-service-stub.ts
@@ -83,7 +83,7 @@ export class BackendServiceStub extends BaseBackendService {
     });
   }
 
-  editPoem(editedPoem: Poem): Observable<EditPoemResponse> {
+  editPoem(editedPoem: Poem): Observable<EditPoemResponse|undefined> {
     const originalPoem: Poem|undefined =
         this.poem.find(p => p.id == editedPoem.id);
     if (editedPoem.id == undefined || !originalPoem) {


### PR DESCRIPTION
Create ui interface to allow users to edit manually written poems.

Previously, users had no way to edit manual poems.
Now, each poem card has an edit button that opens the poem edit dialog:
![image](https://user-images.githubusercontent.com/15317173/118867296-875d7e80-b8a8-11eb-8787-714be6bdb23e.png)

Edit dialog:
![image](https://user-images.githubusercontent.com/15317173/118867331-93e1d700-b8a8-11eb-9f39-260ca209e539.png)

Added tests to:
- check that the edit dialog populates existing poem info
- check that the edit dialog saved the edited poem
- check that the edit dialog's snackbar message shows an error if the save fails
- check that the poem list passes the existing poem to the edit dialog